### PR TITLE
Removed animation on bottom sheet

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -251,28 +251,13 @@ fun Success(
         modifier = modifier
             .pointerInput(Unit) {
                 detectVerticalDragGestures(
-                    onDragEnd = {
-                        scope.launch {
-                            if (applicationScreenY.value < constraintsMaxHeight / 2) {
-                                applicationScreenY.animateTo(0f)
-                            } else {
-                                applicationScreenY.animateTo(screenHeight)
-
-                                onShowGridCache(Screen.Pager)
-                            }
-                        }
-                    },
                     onVerticalDrag = { change, dragAmount ->
                         change.consume()
 
-                        scope.launch {
-                            val newY = applicationScreenY.value + dragAmount
-
-                            applicationScreenY.snapTo(newY)
-
-                            if (dragAmount < -50f) {
-                                onShowGridCache(Screen.Application)
-                            }
+                        if(dragAmount < 0f) {
+                            onShowGridCache(Screen.Application)
+                        } else {
+                            onShowGridCache(Screen.Pager)
                         }
                     },
                 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -135,7 +135,7 @@ fun ApplicationScreen(
             override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
                 scope.launch {
                     if (accumulated.value > constraintsMaxHeight / 2) {
-                        onClose()
+
                     } else {
                         accumulated.animateTo(0f)
                     }
@@ -172,15 +172,13 @@ fun ApplicationScreen(
     }
 
     Box(
-        modifier = Modifier
-            .offset { IntOffset(0, applicationScreenY.roundToInt()) }
+        modifier = modifier
             .fillMaxSize()
             .nestedScroll(nestedScrollConnection),
     ) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
-            modifier = modifier
-                .offset { IntOffset(0, accumulated.value.roundToInt()) }
+            modifier = Modifier
                 .fillMaxWidth(),
             state = gridState,
         ) {


### PR DESCRIPTION
We will move the nested scroll connection of application screen to home screen then listen to scroll up and down when on top. We initially don't put animation yet to test show and hide composable