### PR TITLE
Refactored grid item moving and resizing logic

### DIFF
--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/GridItemConstraints.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/GridItemConstraints.kt
@@ -26,11 +26,10 @@ fun isGridItemSpanWithinBounds(gridItem: GridItem, rows: Int, columns: Int): Boo
  * @return True if the rectangular regions defined by the items overlap.
  */
 fun rectanglesOverlap(movingGridItem: GridItem, gridItem: GridItem): Boolean {
-    if (movingGridItem.startRow + movingGridItem.rowSpan <= gridItem.startRow || gridItem.startRow + gridItem.rowSpan <= movingGridItem.startRow) {
-        return false
-    }
-    if (movingGridItem.startColumn + movingGridItem.columnSpan <= gridItem.startColumn || gridItem.startColumn + gridItem.columnSpan <= movingGridItem.startColumn) {
-        return false
-    }
-    return true
+    val noOverlap = movingGridItem.startRow + movingGridItem.rowSpan <= gridItem.startRow ||
+            gridItem.startRow + gridItem.rowSpan <= movingGridItem.startRow ||
+            movingGridItem.startColumn + movingGridItem.columnSpan <= gridItem.startColumn ||
+            gridItem.startColumn + gridItem.columnSpan <= movingGridItem.startColumn
+
+    return !noOverlap
 }

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
@@ -42,18 +42,14 @@ suspend fun resolveConflictsWhenMoving(
                 ResolveDirection.Start
             }
         }
-    }
+    } ?: ResolveDirection.Center
 
     return if (resolveConflicts(
             gridItems = gridItems,
             movingGridItem = movingGridItem,
             resolveDirection = resolveDirection,
-            x = x,
-            y = y,
             rows = rows,
             columns = columns,
-            gridWidth = gridWidth,
-            gridHeight = gridHeight,
         )
     ) {
         gridItems
@@ -64,14 +60,10 @@ suspend fun resolveConflictsWhenMoving(
 
 private suspend fun resolveConflicts(
     gridItems: MutableList<GridItem>,
+    resolveDirection: ResolveDirection,
     movingGridItem: GridItem,
-    resolveDirection: ResolveDirection?,
-    x: Int,
-    y: Int,
     rows: Int,
     columns: Int,
-    gridWidth: Int,
-    gridHeight: Int,
 ): Boolean {
     for (gridItem in gridItems) {
         if (!coroutineContext.isActive) return false
@@ -80,7 +72,7 @@ private suspend fun resolveConflicts(
         if (gridItem.id == movingGridItem.id) continue
 
         if (rectanglesOverlap(movingGridItem = movingGridItem, gridItem = gridItem)) {
-            val shiftedGridItem = moveGridItem(
+            val shiftedItem = moveGridItem(
                 resolveDirection = resolveDirection,
                 movingGridItem = movingGridItem,
                 conflictingGridItem = gridItem,
@@ -91,19 +83,15 @@ private suspend fun resolveConflicts(
             // Update the grid with the shifted item.
             val index = gridItems.indexOfFirst { it.id == gridItem.id }
 
-            gridItems[index] = shiftedGridItem
+            gridItems[index] = shiftedItem
 
             // Recursively resolve further conflicts from the shifted item.
             if (!resolveConflicts(
                     gridItems = gridItems,
-                    movingGridItem = movingGridItem,
                     resolveDirection = resolveDirection,
-                    x = x,
-                    y = y,
+                    movingGridItem = shiftedItem,
                     rows = rows,
                     columns = columns,
-                    gridWidth = gridWidth,
-                    gridHeight = gridHeight,
                 )
             ) {
                 return false

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
@@ -9,11 +9,9 @@ suspend fun resolveConflictsWhenMoving(
     gridItems: MutableList<GridItem>,
     movingGridItem: GridItem,
     x: Int,
-    y: Int,
     rows: Int,
     columns: Int,
     gridWidth: Int,
-    gridHeight: Int,
 ): List<GridItem>? {
     val resolveDirection = gridItems.find { gridItem ->
         gridItem.id != movingGridItem.id && rectanglesOverlap(

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveAlgorithm.kt
@@ -16,12 +16,10 @@ suspend fun resolveConflictsWhenMoving(
     gridHeight: Int,
 ): List<GridItem>? {
     val resolveDirection = gridItems.find { gridItem ->
-        coroutineContext.isActive &&
-                gridItem.id != movingGridItem.id &&
-                rectanglesOverlap(
-                    movingGridItem = movingGridItem,
-                    gridItem = gridItem,
-                )
+        gridItem.id != movingGridItem.id && rectanglesOverlap(
+            movingGridItem = movingGridItem,
+            gridItem = gridItem,
+        )
     }?.let { gridItem ->
         val cellWidth = gridWidth / columns
 
@@ -44,9 +42,7 @@ suspend fun resolveConflictsWhenMoving(
                 ResolveDirection.Start
             }
         }
-    } ?: ResolveDirection.Center
-
-    println("$resolveDirection")
+    }
 
     return if (resolveConflicts(
             gridItems = gridItems,
@@ -69,7 +65,7 @@ suspend fun resolveConflictsWhenMoving(
 private suspend fun resolveConflicts(
     gridItems: MutableList<GridItem>,
     movingGridItem: GridItem,
-    resolveDirection: ResolveDirection,
+    resolveDirection: ResolveDirection?,
     x: Int,
     y: Int,
     rows: Int,
@@ -119,7 +115,7 @@ private suspend fun resolveConflicts(
 }
 
 fun moveGridItem(
-    resolveDirection: ResolveDirection,
+    resolveDirection: ResolveDirection?,
     movingGridItem: GridItem,
     conflictingGridItem: GridItem,
     rows: Int,
@@ -144,7 +140,7 @@ fun moveGridItem(
             )
         }
 
-        ResolveDirection.Center -> null
+        ResolveDirection.Center, null -> null
     }
 }
 

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/ResizeAlgorithm.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/ResizeAlgorithm.kt
@@ -12,14 +12,14 @@ suspend fun resolveConflictsWhenResizing(
     rows: Int,
     columns: Int,
 ): List<GridItem>? {
-    val gridItemShift = getGridItemShift(
+    val resolveDirection = getResolveDirection(
         oldGridItem = oldGridItem,
         resizingGridItem = resizingGridItem,
     )
 
     return if (resolveConflicts(
             gridItems = gridItems,
-            resolveDirection = gridItemShift,
+            resolveDirection = resolveDirection,
             resizingGridItem = resizingGridItem,
             rows = rows,
             columns = columns,
@@ -31,7 +31,7 @@ suspend fun resolveConflictsWhenResizing(
     }
 }
 
-private suspend fun resolveConflicts(
+ private suspend fun resolveConflicts(
     gridItems: MutableList<GridItem>,
     resolveDirection: ResolveDirection,
     resizingGridItem: GridItem,
@@ -75,7 +75,7 @@ private suspend fun resolveConflicts(
     return true
 }
 
-private fun getGridItemShift(
+private fun getResolveDirection(
     oldGridItem: GridItem,
     resizingGridItem: GridItem,
 ): ResolveDirection {

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/ResizeAlgorithm.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/ResizeAlgorithm.kt
@@ -1,0 +1,96 @@
+package com.eblan.launcher.domain.grid
+
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.ResolveDirection
+import kotlinx.coroutines.isActive
+import kotlin.coroutines.coroutineContext
+
+suspend fun resolveConflictsWhenResizing(
+    gridItems: MutableList<GridItem>,
+    oldGridItem: GridItem,
+    resizingGridItem: GridItem,
+    rows: Int,
+    columns: Int,
+): List<GridItem>? {
+    val gridItemShift = getGridItemShift(
+        oldGridItem = oldGridItem,
+        resizingGridItem = resizingGridItem,
+    )
+
+    return if (resolveConflicts(
+            gridItems = gridItems,
+            resolveDirection = gridItemShift,
+            resizingGridItem = resizingGridItem,
+            rows = rows,
+            columns = columns,
+        )
+    ) {
+        gridItems
+    } else {
+        null
+    }
+}
+
+private suspend fun resolveConflicts(
+    gridItems: MutableList<GridItem>,
+    resolveDirection: ResolveDirection,
+    resizingGridItem: GridItem,
+    rows: Int,
+    columns: Int,
+): Boolean {
+    for (gridItem in gridItems) {
+        if (!coroutineContext.isActive) return false
+
+        // Skip the moving grid item itself.
+        if (gridItem.id == resizingGridItem.id) continue
+
+        if (rectanglesOverlap(movingGridItem = resizingGridItem, gridItem = gridItem)) {
+            val shiftedItem = moveGridItem(
+                resolveDirection = resolveDirection,
+                movingGridItem = resizingGridItem,
+                conflictingGridItem = gridItem,
+                rows = rows,
+                columns = columns,
+            ) ?: return false
+
+            // Update the grid with the shifted item.
+            val index = gridItems.indexOfFirst { it.id == gridItem.id }
+
+            gridItems[index] = shiftedItem
+
+            // Recursively resolve further conflicts from the shifted item.
+            if (!resolveConflicts(
+                    gridItems = gridItems,
+                    resolveDirection = resolveDirection,
+                    resizingGridItem = shiftedItem,
+                    rows = rows,
+                    columns = columns,
+                )
+            ) {
+                return false
+            }
+        }
+    }
+
+    return true
+}
+
+private fun getGridItemShift(
+    oldGridItem: GridItem,
+    resizingGridItem: GridItem,
+): ResolveDirection {
+    val oldCenterRow = oldGridItem.startRow + oldGridItem.rowSpan / 2.0
+    val oldCenterColumn = oldGridItem.startColumn + oldGridItem.columnSpan / 2.0
+
+    val newCenterRow = resizingGridItem.startRow + resizingGridItem.rowSpan / 2.0
+    val newCenterColumn = resizingGridItem.startColumn + resizingGridItem.columnSpan / 2.0
+
+    val rowDiff = newCenterRow - oldCenterRow
+    val columnDiff = newCenterColumn - oldCenterColumn
+
+    return when {
+        rowDiff < 0 || columnDiff < 0 -> ResolveDirection.Start
+        rowDiff > 0 || columnDiff > 0 -> ResolveDirection.End
+        else -> ResolveDirection.Center
+    }
+}

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemLayoutInfo.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemLayoutInfo.kt
@@ -1,6 +1,4 @@
-package com.eblan.launcher.feature.home.model
-
-import com.eblan.launcher.domain.model.GridItem
+package com.eblan.launcher.domain.model
 
 data class GridItemLayoutInfo(
     val gridItem: GridItem,

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemShift.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemShift.kt
@@ -1,5 +1,0 @@
-package com.eblan.launcher.domain.model
-
-enum class GridItemShift {
-    Left, Right, Up, Down
-}

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ResolveDirection.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ResolveDirection.kt
@@ -1,0 +1,5 @@
+package com.eblan.launcher.domain.model
+
+enum class ResolveDirection {
+    Start, Center, End,
+}

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
@@ -16,11 +16,9 @@ class MoveGridItemUseCase @Inject constructor(
     suspend operator fun invoke(
         movingGridItem: GridItem,
         x: Int,
-        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
-        gridHeight: Int,
     ): List<GridItem>? {
         return withContext(Dispatchers.Default) {
             if (isGridItemSpanWithinBounds(
@@ -58,11 +56,9 @@ class MoveGridItemUseCase @Inject constructor(
                         gridItems = gridItems,
                         movingGridItem = movingGridItem,
                         x = x,
-                        y = y,
                         rows = rows,
                         columns = columns,
                         gridWidth = gridWidth,
-                        gridHeight = gridHeight,
                     )
 
                     if (resolvedConflictsGridItems != null) {
@@ -77,11 +73,9 @@ class MoveGridItemUseCase @Inject constructor(
                         gridItems = gridItems,
                         movingGridItem = movingGridItem,
                         x = x,
-                        y = y,
                         rows = rows,
                         columns = columns,
                         gridWidth = gridWidth,
-                        gridHeight = gridHeight,
                     )
 
                     if (resolvedConflictsGridItems != null) {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
@@ -4,6 +4,7 @@ import com.eblan.launcher.domain.grid.isGridItemSpanWithinBounds
 import com.eblan.launcher.domain.grid.resolveConflictsWhenMoving
 import com.eblan.launcher.domain.model.Associate
 import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.ResolveDirection
 import com.eblan.launcher.domain.repository.GridCacheRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -16,9 +17,11 @@ class MoveGridItemUseCase @Inject constructor(
     suspend operator fun invoke(
         movingGridItem: GridItem,
         x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
+        gridHeight: Int,
     ): List<GridItem>? {
         return withContext(Dispatchers.Default) {
             if (isGridItemSpanWithinBounds(
@@ -47,46 +50,145 @@ class MoveGridItemUseCase @Inject constructor(
                     }
                 }.toMutableList()
 
+                val gridItemByCoordinates = getGridItemByCoordinates(
+                    movingGridItem = movingGridItem,
+                    gridItems = gridItems,
+                    rows = rows,
+                    columns = columns,
+                    x = x,
+                    y = y,
+                    gridWidth = gridWidth,
+                    gridHeight = gridHeight,
+                )
+
                 val index = gridItems.indexOfFirst { it.id == movingGridItem.id }
 
                 if (index != -1) {
                     gridItems[index] = movingGridItem
 
-                    val resolvedConflictsGridItems = resolveConflictsWhenMoving(
-                        gridItems = gridItems,
-                        movingGridItem = movingGridItem,
-                        x = x,
-                        rows = rows,
-                        columns = columns,
-                        gridWidth = gridWidth,
-                    )
+                    if (gridItemByCoordinates != null) {
+                        val resolveDirection = getResolveDirection(
+                            gridItem = gridItemByCoordinates,
+                            x = x,
+                            columns = columns,
+                            gridWidth = gridWidth,
+                        )
 
-                    if (resolvedConflictsGridItems != null) {
-                        gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                        val resolvedConflictsGridItems = resolveConflictsWhenMoving(
+                            gridItems = gridItems,
+                            resolveDirection = resolveDirection,
+                            movingGridItem = movingGridItem,
+                            x = x,
+                            rows = rows,
+                            columns = columns,
+                            gridWidth = gridWidth,
+                        )
+
+                        println(resolvedConflictsGridItems)
+
+                        if (resolvedConflictsGridItems != null) {
+                            gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                        }
+
+                        resolvedConflictsGridItems
+                    } else {
+                        gridCacheRepository.upsertGridItems(gridItems = gridItems)
+
+                        gridItems
                     }
-
-                    resolvedConflictsGridItems
                 } else {
                     gridItems.add(movingGridItem)
 
-                    val resolvedConflictsGridItems = resolveConflictsWhenMoving(
-                        gridItems = gridItems,
-                        movingGridItem = movingGridItem,
-                        x = x,
-                        rows = rows,
-                        columns = columns,
-                        gridWidth = gridWidth,
-                    )
+                    if (gridItemByCoordinates != null) {
+                        val resolveDirection = getResolveDirection(
+                            gridItem = gridItemByCoordinates,
+                            x = x,
+                            columns = columns,
+                            gridWidth = gridWidth,
+                        )
 
-                    if (resolvedConflictsGridItems != null) {
-                        gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                        val resolvedConflictsGridItems = resolveConflictsWhenMoving(
+                            gridItems = gridItems,
+                            resolveDirection = resolveDirection,
+                            movingGridItem = movingGridItem,
+                            x = x,
+                            rows = rows,
+                            columns = columns,
+                            gridWidth = gridWidth,
+                        )
+
+                        if (resolvedConflictsGridItems != null) {
+                            gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                        }
+
+                        resolvedConflictsGridItems
+                    } else {
+                        gridCacheRepository.upsertGridItems(gridItems = gridItems)
+
+                        gridItems
                     }
-
-                    resolvedConflictsGridItems
                 }
             } else {
                 null
             }
+        }
+    }
+
+    private fun getGridItemByCoordinates(
+        movingGridItem: GridItem,
+        gridItems: List<GridItem>,
+        rows: Int,
+        columns: Int,
+        x: Int,
+        y: Int,
+        gridWidth: Int,
+        gridHeight: Int,
+    ): GridItem? {
+        val cellWidth = gridWidth / rows
+
+        val cellHeight = gridHeight / columns
+
+        return gridItems.find { gridItem ->
+            val startRow = y / cellHeight
+
+            val startColumn = x / cellWidth
+
+            val rowInSpan =
+                startRow in gridItem.startRow until (gridItem.startRow + gridItem.rowSpan)
+
+            val columnInSpan =
+                startColumn in gridItem.startColumn until (gridItem.startColumn + gridItem.columnSpan)
+
+            gridItem.page == movingGridItem.page && gridItem.id != movingGridItem.id && rowInSpan && columnInSpan
+        }
+    }
+}
+
+private fun getResolveDirection(
+    gridItem: GridItem,
+    x: Int,
+    columns: Int,
+    gridWidth: Int,
+): ResolveDirection {
+    val cellWidth = gridWidth / columns
+
+    val gridItemX = gridItem.startColumn * cellWidth
+
+    val gridItemWidth = gridItem.columnSpan * cellWidth
+
+    val xInGridItem = x - gridItemX
+
+    return when {
+        xInGridItem < gridItemWidth / 3 -> {
+            ResolveDirection.End
+        }
+
+        xInGridItem < 2 * gridItemWidth / 3 -> {
+            ResolveDirection.Center
+        }
+
+        else -> {
+            ResolveDirection.Start
         }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveGridItemUseCase.kt
@@ -1,0 +1,98 @@
+package com.eblan.launcher.domain.usecase
+
+import com.eblan.launcher.domain.grid.isGridItemSpanWithinBounds
+import com.eblan.launcher.domain.grid.resolveConflictsWhenMoving
+import com.eblan.launcher.domain.model.Associate
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.repository.GridCacheRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class MoveGridItemUseCase @Inject constructor(
+    private val gridCacheRepository: GridCacheRepository,
+) {
+    suspend operator fun invoke(
+        movingGridItem: GridItem,
+        x: Int,
+        y: Int,
+        rows: Int,
+        columns: Int,
+        gridWidth: Int,
+        gridHeight: Int,
+    ): List<GridItem>? {
+        return withContext(Dispatchers.Default) {
+            if (isGridItemSpanWithinBounds(
+                    gridItem = movingGridItem,
+                    rows = rows,
+                    columns = columns,
+                )
+            ) {
+                val gridItems = gridCacheRepository.gridCacheItems.first().filter { gridItem ->
+                    when (movingGridItem.associate) {
+                        Associate.Grid -> {
+                            isGridItemSpanWithinBounds(
+                                gridItem = gridItem,
+                                rows = rows,
+                                columns = columns,
+                            ) && gridItem.page == movingGridItem.page && gridItem.associate == Associate.Grid
+                        }
+
+                        Associate.Dock -> {
+                            isGridItemSpanWithinBounds(
+                                gridItem = gridItem,
+                                rows = rows,
+                                columns = columns,
+                            ) && gridItem.associate == Associate.Dock
+                        }
+                    }
+                }.toMutableList()
+
+                val index = gridItems.indexOfFirst { it.id == movingGridItem.id }
+
+                if (index != -1) {
+                    gridItems[index] = movingGridItem
+
+                    val resolvedConflictsGridItems = resolveConflictsWhenMoving(
+                        gridItems = gridItems,
+                        movingGridItem = movingGridItem,
+                        x = x,
+                        y = y,
+                        rows = rows,
+                        columns = columns,
+                        gridWidth = gridWidth,
+                        gridHeight = gridHeight,
+                    )
+
+                    if (resolvedConflictsGridItems != null) {
+                        gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                    }
+
+                    resolvedConflictsGridItems
+                } else {
+                    gridItems.add(movingGridItem)
+
+                    val resolvedConflictsGridItems = resolveConflictsWhenMoving(
+                        gridItems = gridItems,
+                        movingGridItem = movingGridItem,
+                        x = x,
+                        y = y,
+                        rows = rows,
+                        columns = columns,
+                        gridWidth = gridWidth,
+                        gridHeight = gridHeight,
+                    )
+
+                    if (resolvedConflictsGridItems != null) {
+                        gridCacheRepository.upsertGridItems(gridItems = resolvedConflictsGridItems)
+                    }
+
+                    resolvedConflictsGridItems
+                }
+            } else {
+                null
+            }
+        }
+    }
+}

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/ResizeGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/ResizeGridItemUseCase.kt
@@ -1,7 +1,7 @@
 package com.eblan.launcher.domain.usecase
 
 import com.eblan.launcher.domain.grid.isGridItemSpanWithinBounds
-import com.eblan.launcher.domain.grid.resolveConflictsWithShift
+import com.eblan.launcher.domain.grid.resolveConflictsWhenResizing
 import com.eblan.launcher.domain.model.Associate
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.repository.GridCacheRepository
@@ -10,29 +10,29 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class ShiftAlgorithmUseCase @Inject constructor(
+class ResizeGridItemUseCase @Inject constructor(
     private val gridCacheRepository: GridCacheRepository,
 ) {
     suspend operator fun invoke(
-        movingGridItem: GridItem,
+        resizingGridItem: GridItem,
         rows: Int,
         columns: Int,
     ): List<GridItem>? {
         return withContext(Dispatchers.Default) {
             if (isGridItemSpanWithinBounds(
-                    gridItem = movingGridItem,
+                    gridItem = resizingGridItem,
                     rows = rows,
                     columns = columns,
                 )
             ) {
                 val gridItems = gridCacheRepository.gridCacheItems.first().filter { gridItem ->
-                    when (movingGridItem.associate) {
+                    when (resizingGridItem.associate) {
                         Associate.Grid -> {
                             isGridItemSpanWithinBounds(
                                 gridItem = gridItem,
                                 rows = rows,
                                 columns = columns,
-                            ) && gridItem.page == movingGridItem.page && gridItem.associate == Associate.Grid
+                            ) && gridItem.page == resizingGridItem.page && gridItem.associate == Associate.Grid
                         }
 
                         Associate.Dock -> {
@@ -45,17 +45,17 @@ class ShiftAlgorithmUseCase @Inject constructor(
                     }
                 }.toMutableList()
 
-                val index = gridItems.indexOfFirst { it.id == movingGridItem.id }
+                val index = gridItems.indexOfFirst { it.id == resizingGridItem.id }
 
-                if(index != -1) {
+                if (index != -1) {
                     val oldGridItem = gridItems[index]
 
-                    gridItems[index] = movingGridItem
+                    gridItems[index] = resizingGridItem
 
-                    val resolvedConflictsGridItems = resolveConflictsWithShift(
+                    val resolvedConflictsGridItems = resolveConflictsWhenResizing(
                         gridItems = gridItems,
                         oldGridItem = oldGridItem,
-                        movingGridItem = movingGridItem,
+                        resizingGridItem = resizingGridItem,
                         rows = rows,
                         columns = columns,
                     )
@@ -66,12 +66,12 @@ class ShiftAlgorithmUseCase @Inject constructor(
 
                     resolvedConflictsGridItems
                 } else {
-                    gridItems.add(movingGridItem)
+                    gridItems.add(resizingGridItem)
 
-                    val resolvedConflictsGridItems = resolveConflictsWithShift(
+                    val resolvedConflictsGridItems = resolveConflictsWhenResizing(
                         gridItems = gridItems,
-                        oldGridItem = movingGridItem,
-                        movingGridItem = movingGridItem,
+                        oldGridItem = resizingGridItem,
+                        resizingGridItem = resizingGridItem,
                         rows = rows,
                         columns = columns,
                     )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -105,11 +105,9 @@ fun HomeScreen(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
-        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
-        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,
@@ -183,11 +181,9 @@ fun Success(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
-        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
-        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -103,9 +103,13 @@ fun HomeScreen(
     eblanAppWidgetProviderInfosByGroup: Map<EblanApplicationInfo, List<EblanAppWidgetProviderInfo>>,
     shiftedAlgorithm: Boolean?,
     onMoveGridItem: (
-        gridItem: GridItem,
+        movingGridItem: GridItem,
+        x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
+        gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,
@@ -177,9 +181,13 @@ fun Success(
     dockGridItems: List<GridItem>,
     shiftedAlgorithm: Boolean?,
     onMoveGridItem: (
-        gridItem: GridItem,
+        movingGridItem: GridItem,
+        x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
+        gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -105,9 +105,11 @@ fun HomeScreen(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,
@@ -181,9 +183,11 @@ fun Success(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onResizeGridItem: (
         gridItem: GridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -10,7 +10,8 @@ import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.GridCacheRepository
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.usecase.GroupGridItemsByPageUseCase
-import com.eblan.launcher.domain.usecase.ShiftAlgorithmUseCase
+import com.eblan.launcher.domain.usecase.MoveGridItemUseCase
+import com.eblan.launcher.domain.usecase.ResizeGridItemUseCase
 import com.eblan.launcher.domain.usecase.UpdateGridItemsUseCase
 import com.eblan.launcher.feature.home.model.HomeUiState
 import com.eblan.launcher.feature.home.model.Screen
@@ -36,7 +37,8 @@ class HomeViewModel @Inject constructor(
     private val gridRepository: GridRepository,
     private val gridCacheRepository: GridCacheRepository,
     private val packageManagerWrapper: PackageManagerWrapper,
-    private val shiftAlgorithmUseCase: ShiftAlgorithmUseCase,
+    private val moveGridItemUseCase: MoveGridItemUseCase,
+    private val resizeGridItemUseCase: ResizeGridItemUseCase,
     private val updateGridItemsUseCase: UpdateGridItemsUseCase,
 ) : ViewModel() {
     private val _isCache = MutableStateFlow(false)
@@ -84,30 +86,38 @@ class HomeViewModel @Inject constructor(
     val shiftedAlgorithm = _shiftedAlgorithm.asStateFlow()
 
     fun moveGridItem(
-        gridItem: GridItem,
+        movingGridItem: GridItem,
+        x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
+        gridWidth: Int,
+        gridHeight: Int,
     ) {
         viewModelScope.launch {
             _shiftedAlgorithm.update {
-                shiftAlgorithmUseCase(
-                    movingGridItem = gridItem,
+                moveGridItemUseCase(
+                    movingGridItem = movingGridItem,
+                    x = x,
+                    y = y,
                     rows = rows,
                     columns = columns,
+                    gridWidth = gridWidth,
+                    gridHeight = gridHeight,
                 ) != null
             }
         }
     }
 
     fun resizeGridItem(
-        gridItem: GridItem,
+        resizingGridItem: GridItem,
         rows: Int,
         columns: Int,
     ) {
         viewModelScope.launch {
             _shiftedAlgorithm.update {
-                shiftAlgorithmUseCase(
-                    movingGridItem = gridItem,
+                resizeGridItemUseCase(
+                    resizingGridItem = resizingGridItem,
                     rows = rows,
                     columns = columns,
                 ) != null

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -88,18 +88,22 @@ class HomeViewModel @Inject constructor(
     fun moveGridItem(
         movingGridItem: GridItem,
         x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
+        gridHeight: Int,
     ) {
         viewModelScope.launch {
             _shiftedAlgorithm.update {
                 moveGridItemUseCase(
                     movingGridItem = movingGridItem,
                     x = x,
+                    y = y,
                     rows = rows,
                     columns = columns,
                     gridWidth = gridWidth,
+                    gridHeight = gridHeight,
                 ) != null
             }
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -88,22 +88,18 @@ class HomeViewModel @Inject constructor(
     fun moveGridItem(
         movingGridItem: GridItem,
         x: Int,
-        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
-        gridHeight: Int,
     ) {
         viewModelScope.launch {
             _shiftedAlgorithm.update {
                 moveGridItemUseCase(
                     movingGridItem = movingGridItem,
                     x = x,
-                    y = y,
                     rows = rows,
                     columns = columns,
                     gridWidth = gridWidth,
-                    gridHeight = gridHeight,
                 ) != null
             }
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/GridItemSource.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/GridItemSource.kt
@@ -1,5 +1,7 @@
 package com.eblan.launcher.feature.home.model
 
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
+
 data class GridItemSource(val gridItemLayoutInfo: GridItemLayoutInfo, val type: Type) {
     enum class Type {
         New, Old,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -49,7 +49,7 @@ import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.component.ApplicationInfoMenu
 import com.eblan.launcher.feature.home.model.Drag
-import com.eblan.launcher.feature.home.model.GridItemLayoutInfo
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
 import com.eblan.launcher.feature.home.screen.pager.GridItemMenu
 import com.eblan.launcher.feature.home.util.calculatePage
 import kotlinx.coroutines.launch

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -227,6 +227,10 @@ fun DragScreen(
         moveGridItem?.let { (gridItemLayoutInfo, rows, columns) ->
             delay(500L)
 
+            val gridWidth = rootWidth - (horizontalPagerPaddingPx * 2)
+
+            val gridHeight = rootHeight - ((horizontalPagerPaddingPx * 2) + dockHeight)
+
             val gridX = dragIntOffset.x - horizontalPagerPaddingPx
 
             val gridY = dragIntOffset.y - horizontalPagerPaddingPx
@@ -237,8 +241,8 @@ fun DragScreen(
                 gridY,
                 rows,
                 columns,
-                rootWidth,
-                rootHeight,
+                gridWidth,
+                gridHeight,
             )
         }
     }
@@ -616,11 +620,9 @@ private fun onDragEndGridItemDataWidget(
     appWidgetLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
 ) {
     if (shiftedAlgorithm != null && shiftedAlgorithm) {
-        val allocateAppWidgetId =
-            appWidgetHost.allocateAppWidgetId()
+        val allocateAppWidgetId = appWidgetHost.allocateAppWidgetId()
 
-        val provider =
-            ComponentName.unflattenFromString(data.componentName)
+        val provider = ComponentName.unflattenFromString(data.componentName)
 
         if (appWidgetManager.bindAppWidgetIdIfAllowed(
                 appWidgetId = allocateAppWidgetId,
@@ -635,17 +637,16 @@ private fun onDragEndGridItemDataWidget(
 
             onDragEnd(targetPage)
         } else {
-            val intent =
-                Intent(AppWidgetManager.ACTION_APPWIDGET_BIND).apply {
-                    putExtra(
-                        AppWidgetManager.EXTRA_APPWIDGET_ID,
-                        allocateAppWidgetId,
-                    )
-                    putExtra(
-                        AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
-                        provider,
-                    )
-                }
+            val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_BIND).apply {
+                putExtra(
+                    AppWidgetManager.EXTRA_APPWIDGET_ID,
+                    allocateAppWidgetId,
+                )
+                putExtra(
+                    AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
+                    provider,
+                )
+            }
 
             appWidgetLauncher.launch(intent)
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -90,11 +90,9 @@ fun DragScreen(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
-        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
-        gridHeight: Int,
     ) -> Unit,
     onUpdateWidgetGridItem: (
         id: String,
@@ -229,20 +227,14 @@ fun DragScreen(
 
             val gridWidth = rootWidth - (horizontalPagerPaddingPx * 2)
 
-            val gridHeight = rootHeight - ((horizontalPagerPaddingPx * 2) + dockHeight)
-
             val gridX = dragIntOffset.x - horizontalPagerPaddingPx
-
-            val gridY = dragIntOffset.y - horizontalPagerPaddingPx
 
             onMoveGridItem(
                 gridItemLayoutInfo,
                 gridX,
-                gridY,
                 rows,
                 columns,
                 gridWidth,
-                gridHeight,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -90,9 +90,11 @@ fun DragScreen(
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
         gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onUpdateWidgetGridItem: (
         id: String,
@@ -227,14 +229,20 @@ fun DragScreen(
 
             val gridWidth = rootWidth - (horizontalPagerPaddingPx * 2)
 
+            val gridHeight = rootHeight - ((horizontalPagerPaddingPx * 2) + dockHeight)
+
             val gridX = dragIntOffset.x - horizontalPagerPaddingPx
+
+            val gridY = dragIntOffset.y - horizontalPagerPaddingPx
 
             onMoveGridItem(
                 gridItemLayoutInfo,
                 gridX,
+                gridY,
                 rows,
                 columns,
                 gridWidth,
+                gridHeight,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -50,6 +50,7 @@ import com.eblan.launcher.designsystem.local.LocalAppWidgetManager
 import com.eblan.launcher.domain.model.Associate
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
 import com.eblan.launcher.domain.model.PageDirection
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.component.ApplicationInfoGridItemMenu
@@ -57,7 +58,6 @@ import com.eblan.launcher.feature.home.component.DockGrid
 import com.eblan.launcher.feature.home.component.DragGridSubcomposeLayout
 import com.eblan.launcher.feature.home.component.WidgetGridItemMenu
 import com.eblan.launcher.feature.home.model.Drag
-import com.eblan.launcher.feature.home.model.GridItemLayoutInfo
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.MoveGridItem
 import com.eblan.launcher.feature.home.screen.pager.GridItemMenu
@@ -88,9 +88,13 @@ fun DragScreen(
     shiftedAlgorithm: Boolean?,
     addNewPage: Boolean,
     onMoveGridItem: (
-        gridItem: GridItem,
+        movingGridItem: GridItem,
+        x: Int,
+        y: Int,
         rows: Int,
         columns: Int,
+        gridWidth: Int,
+        gridHeight: Int,
     ) -> Unit,
     onUpdateWidgetGridItem: (
         id: String,
@@ -220,10 +224,22 @@ fun DragScreen(
     }
 
     LaunchedEffect(key1 = moveGridItem) {
-        moveGridItem?.let { (gridItem, rows, columns) ->
+        moveGridItem?.let { (gridItemLayoutInfo, rows, columns) ->
             delay(500L)
 
-            onMoveGridItem(gridItem, rows, columns)
+            val gridX = dragIntOffset.x - horizontalPagerPaddingPx
+
+            val gridY = dragIntOffset.y - horizontalPagerPaddingPx
+
+            onMoveGridItem(
+                gridItemLayoutInfo,
+                gridX,
+                gridY,
+                rows,
+                columns,
+                rootWidth,
+                rootHeight,
+            )
         }
     }
 
@@ -264,7 +280,9 @@ fun DragScreen(
                                 when (val gridItemData = gridItem.data) {
                                     is GridItemData.ApplicationInfo -> {
                                         Column(
-                                            modifier = Modifier.fillMaxSize(),
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .border(width = 1.dp, color = Color.White),
                                             horizontalAlignment = Alignment.CenterHorizontally,
                                         ) {
                                             AsyncImage(
@@ -337,7 +355,9 @@ fun DragScreen(
                     when (val gridItemData = dockGridItem.data) {
                         is GridItemData.ApplicationInfo -> {
                             Column(
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .border(width = 1.dp, color = Color.White),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {
                                 AsyncImage(
@@ -693,6 +713,7 @@ private fun handleDragIntOffset(
                 startColumn = dragIntOffset.x / cellWidth,
                 associate = Associate.Dock,
             )
+
             onChangeMoveGridItem(
                 MoveGridItem(
                     gridItem = gridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -50,7 +50,7 @@ import com.eblan.launcher.feature.home.component.DockGrid
 import com.eblan.launcher.feature.home.component.GridSubcomposeLayout
 import com.eblan.launcher.feature.home.component.MenuPositionProvider
 import com.eblan.launcher.feature.home.model.Drag
-import com.eblan.launcher.feature.home.model.GridItemLayoutInfo
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
 import com.eblan.launcher.feature.home.screen.application.ApplicationScreen
 import com.eblan.launcher.feature.home.screen.widget.WidgetScreen
 import com.eblan.launcher.feature.home.util.calculatePage

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
@@ -26,7 +26,7 @@ import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.component.DockGrid
 import com.eblan.launcher.feature.home.component.ResizeGridSubcomposeLayout
-import com.eblan.launcher.feature.home.model.GridItemLayoutInfo
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
 
 @Composable
 fun ResizeScreen(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -41,7 +41,7 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.model.Drag
-import com.eblan.launcher.feature.home.model.GridItemLayoutInfo
+import com.eblan.launcher.domain.model.GridItemLayoutInfo
 import com.eblan.launcher.feature.home.util.calculatePage
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid


### PR DESCRIPTION
- Renamed `ShiftAlgorithmUseCase` to `ResizeGridItemUseCase` and created a new `MoveGridItemUseCase`.
    - Both use cases now operate on `GridCacheRepository` directly for intermediate updates.
- Introduced `resolveConflictsWhenResizing` and `resolveConflictsWhenMoving` in `domain/grid` to handle conflict resolution specific to resizing and moving operations respectively.
    - `resolveConflictsWhenMoving` now considers the pointer's X and Y coordinates on the grid to determine the `ResolveDirection`.
- Renamed `GridItemShift` enum to `ResolveDirection` and added a `Center` value.
- Moved `GridItemLayoutInfo` from `feature/home/model` to `domain/model`.
- Updated `DragScreen` to:
    - Pass X, Y coordinates, grid width, and grid height to `onMoveGridItem`.
    - Add a 1.dp white border to draggable application info items for visual feedback.
- Modified `rectanglesOverlap` in `GridItemConstraints.kt` for conciseness.
- Adjusted `moveGridItem` (previously `shiftItem`) to accept `ResolveDirection` and return null for `ResolveDirection.Center`.
- Updated `HomeViewModel` to use the new `MoveGridItemUseCase` and the renamed `ResizeGridItemUseCase`, passing additional parameters for moving.
- Updated call sites of `onMoveGridItem` and `onResizeGridItem` in `HomeScreen` and `DragScreen`.

#73