### PR TITLE
Refactor: Simplify page handling in home feature

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveFolderGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/MoveFolderGridItemUseCase.kt
@@ -53,7 +53,7 @@ class MoveFolderGridItemUseCase @Inject constructor(
                     gridItem = gridItem,
                     columns = columns,
                     rows = rows,
-                ) && gridItem.page == movingGridItem.page
+                )
             }.toMutableList()
 
             val index =

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -64,6 +65,7 @@ import com.eblan.launcher.domain.model.HomeData
 import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.domain.model.PageItem
 import com.eblan.launcher.domain.model.PinItemRequestType
+import com.eblan.launcher.feature.home.component.pager.rememberHomePagerState
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.EblanApplicationComponentUiState
 import com.eblan.launcher.feature.home.model.GridItemSource
@@ -76,6 +78,7 @@ import com.eblan.launcher.feature.home.screen.folderdrag.FolderDragScreen
 import com.eblan.launcher.feature.home.screen.loading.LoadingScreen
 import com.eblan.launcher.feature.home.screen.pager.PagerScreen
 import com.eblan.launcher.feature.home.screen.resize.ResizeScreen
+import com.eblan.launcher.feature.home.util.calculatePage
 import com.eblan.launcher.ui.local.LocalPinItemRequest
 import kotlin.math.roundToInt
 
@@ -475,10 +478,30 @@ private fun Success(
 
     var gridItemSource by remember { mutableStateOf<GridItemSource?>(null) }
 
-    var targetPage by remember {
-        mutableIntStateOf(
-            homeData.userData.homeSettings.initialPage,
-        )
+    val gridHorizontalPagerState = rememberHomePagerState(
+        infiniteScroll = homeData.userData.homeSettings.infiniteScroll,
+        initialPage = if (homeData.userData.homeSettings.infiniteScroll) {
+            (Int.MAX_VALUE / 2) + homeData.userData.homeSettings.initialPage
+        } else {
+            homeData.userData.homeSettings.initialPage
+        },
+        pageCount = {
+            if (homeData.userData.homeSettings.infiniteScroll) {
+                Int.MAX_VALUE
+            } else {
+                homeData.userData.homeSettings.pageCount
+            }
+        },
+    )
+
+    val currentPage by remember(gridHorizontalPagerState) {
+        derivedStateOf {
+            calculatePage(
+                index = gridHorizontalPagerState.currentPage,
+                infiniteScroll = homeData.userData.homeSettings.infiniteScroll,
+                pageCount = homeData.userData.homeSettings.pageCount,
+            )
+        }
     }
 
     var folderTargetPage by remember { mutableIntStateOf(0) }
@@ -507,7 +530,6 @@ private fun Success(
         when (targetState) {
             Screen.Pager -> {
                 PagerScreen(
-                    targetPage = targetPage,
                     gridItems = homeData.gridItems,
                     gridItemsByPage = homeData.gridItemsByPage,
                     drag = drag,
@@ -526,14 +548,9 @@ private fun Success(
                     eblanAppWidgetProviderInfosByLabel = eblanAppWidgetProviderInfosByLabel,
                     eblanShortcutInfosByLabel = eblanShortcutInfosByLabel,
                     iconPackInfoPackageName = homeData.userData.generalSettings.iconPackInfoPackageName,
-                    onLongPressGrid = { newCurrentPage ->
-                        targetPage = newCurrentPage
-                    },
-                    onTapFolderGridItem = { newCurrentPage, id ->
-                        targetPage = newCurrentPage
-
-                        onShowFolder(id)
-                    },
+                    gridHorizontalPagerState = gridHorizontalPagerState,
+                    currentPage = currentPage,
+                    onTapFolderGridItem = onShowFolder,
                     onDraggingGridItem = {
                         onShowGridCache(
                             homeData.gridItems,
@@ -543,8 +560,6 @@ private fun Success(
                     },
                     onEdit = onEdit,
                     onResize = { newTargetPage ->
-                        targetPage = newTargetPage
-
                         onShowGridCache(
                             homeData.gridItems,
                             GridItemCacheType.Grid,
@@ -553,9 +568,7 @@ private fun Success(
                     },
                     onSettings = onSettings,
                     onEditPage = onEditPage,
-                    onLongPressGridItem = { newCurrentPage, newGridItemSource, imageBitmap ->
-                        targetPage = newCurrentPage
-
+                    onLongPressGridItem = { newGridItemSource, imageBitmap ->
                         gridItemSource = newGridItemSource
 
                         onUpdateGridItemImageBitmap(imageBitmap)
@@ -570,7 +583,6 @@ private fun Success(
 
             Screen.Drag -> {
                 DragScreen(
-                    startCurrentPage = targetPage,
                     gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage,
                     dragIntOffset = dragIntOffset,
                     gridItemSource = gridItemSource,
@@ -584,30 +596,20 @@ private fun Success(
                     homeSettings = homeData.userData.homeSettings,
                     iconPackInfoPackageName = homeData.userData.generalSettings.iconPackInfoPackageName,
                     hasShortcutHostPermission = homeData.hasShortcutHostPermission,
+                    gridHorizontalPagerState = gridHorizontalPagerState,
+                    currentPage = currentPage,
                     onMoveGridItem = onMoveGridItem,
-                    onDragEndAfterMove = { newTargetPage, movingGridItem, conflictingGridItem ->
-                        targetPage = newTargetPage
-
-                        onResetGridCacheAfterMove(movingGridItem, conflictingGridItem)
-                    },
-                    onMoveGridItemsFailed = { newTargetPage ->
-                        targetPage = newTargetPage
-
-                        onCancelGridCache()
-                    },
+                    onDragEndAfterMove = onResetGridCacheAfterMove,
+                    onMoveGridItemsFailed = onCancelGridCache,
                     onDeleteGridItemCache = onDeleteGridItemCache,
                     onUpdateGridItemDataCache = onUpdateGridItemDataCache,
-                    onDeleteWidgetGridItemCache = { newTargetPage, gridItem, appWidgetId ->
-                        targetPage = newTargetPage
-
-                        onDeleteWidgetGridItemCache(gridItem, appWidgetId)
-                    },
+                    onDeleteWidgetGridItemCache = onDeleteWidgetGridItemCache,
                 )
             }
 
             Screen.Resize -> {
                 ResizeScreen(
-                    gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage[targetPage],
+                    gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage[currentPage],
                     gridItem = gridItemSource?.gridItem,
                     screenWidth = screenWidth,
                     screenHeight = screenHeight,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -32,12 +32,12 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -504,7 +504,11 @@ private fun Success(
         }
     }
 
-    var folderTargetPage by remember { mutableIntStateOf(0) }
+    val folderGridHorizontalPagerState = rememberPagerState(
+        pageCount = {
+            foldersDataById.lastOrNull()?.pageCount ?: 0
+        },
+    )
 
     LaunchedEffect(key1 = pinGridItem) {
         val pinItemRequest = pinItemRequestWrapper.getPinItemRequest()
@@ -644,7 +648,6 @@ private fun Success(
 
             Screen.Folder -> {
                 FolderScreen(
-                    startCurrentPage = folderTargetPage,
                     foldersDataById = foldersDataById,
                     drag = drag,
                     paddingValues = paddingValues,
@@ -654,15 +657,13 @@ private fun Success(
                     textColor = homeData.textColor,
                     homeSettings = homeData.userData.homeSettings,
                     iconPackInfoPackageName = homeData.userData.generalSettings.iconPackInfoPackageName,
+                    folderGridHorizontalPagerState = folderGridHorizontalPagerState,
                     onUpdateScreen = onUpdateScreen,
                     onRemoveLastFolder = onRemoveLastFolder,
                     onAddFolder = onAddFolder,
                     onResetTargetPage = {
-                        folderTargetPage = 0
                     },
                     onLongPressGridItem = { newCurrentPage, newGridItemSource, imageBitmap ->
-                        folderTargetPage = newCurrentPage
-
                         gridItemSource = newGridItemSource
 
                         onUpdateGridItemImageBitmap(imageBitmap)
@@ -680,7 +681,6 @@ private fun Success(
 
             Screen.FolderDrag -> {
                 FolderDragScreen(
-                    startCurrentPage = folderTargetPage,
                     gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage,
                     gridItemSource = gridItemSource,
                     textColor = homeData.textColor,
@@ -694,10 +694,9 @@ private fun Success(
                     iconPackInfoPackageName = homeData.userData.generalSettings.iconPackInfoPackageName,
                     hasShortcutHostPermission = homeData.hasShortcutHostPermission,
                     moveGridItemResult = movedGridItemResult,
+                    folderGridHorizontalPagerState = folderGridHorizontalPagerState,
                     onMoveFolderGridItem = onMoveFolderGridItem,
                     onDragEnd = { newTargetPage ->
-                        folderTargetPage = newTargetPage
-
                         onResetGridCacheAfterMoveFolder()
                     },
                     onDragCancel = onCancelFolderDragGridCache,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -563,7 +563,7 @@ private fun Success(
                         )
                     },
                     onEdit = onEdit,
-                    onResize = { newTargetPage ->
+                    onResize = {
                         onShowGridCache(
                             homeData.gridItems,
                             GridItemCacheType.Grid,
@@ -661,9 +661,7 @@ private fun Success(
                     onUpdateScreen = onUpdateScreen,
                     onRemoveLastFolder = onRemoveLastFolder,
                     onAddFolder = onAddFolder,
-                    onResetTargetPage = {
-                    },
-                    onLongPressGridItem = { newCurrentPage, newGridItemSource, imageBitmap ->
+                    onLongPressGridItem = { newGridItemSource, imageBitmap ->
                         gridItemSource = newGridItemSource
 
                         onUpdateGridItemImageBitmap(imageBitmap)
@@ -696,9 +694,7 @@ private fun Success(
                     moveGridItemResult = movedGridItemResult,
                     folderGridHorizontalPagerState = folderGridHorizontalPagerState,
                     onMoveFolderGridItem = onMoveFolderGridItem,
-                    onDragEnd = { newTargetPage ->
-                        onResetGridCacheAfterMoveFolder()
-                    },
+                    onDragEnd = onResetGridCacheAfterMoveFolder,
                     onDragCancel = onCancelFolderDragGridCache,
                     onMoveOutsideFolder = { newGridItemSource ->
                         gridItemSource = newGridItemSource

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/HomePagerState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/HomePagerState.kt
@@ -1,0 +1,61 @@
+package com.eblan.launcher.feature.home.component.pager
+
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+fun rememberHomePagerState(
+    infiniteScroll: Boolean,
+    initialPage: Int = 0,
+    @FloatRange(from = -0.5, to = 0.5) initialPageOffsetFraction: Float = 0f,
+    pageCount: () -> Int
+): PagerState {
+    return rememberSaveable(
+        infiniteScroll,
+        saver = HomePagerState.Saver
+    ) {
+        HomePagerState(
+            currentPage = initialPage,
+            currentPageOffsetFraction = initialPageOffsetFraction,
+            updatedPageCount = pageCount
+        )
+    }
+        .apply { pageCountState.value = pageCount }
+}
+
+private class HomePagerState(
+    currentPage: Int,
+    currentPageOffsetFraction: Float,
+    updatedPageCount: () -> Int
+) : PagerState(currentPage, currentPageOffsetFraction) {
+
+    var pageCountState = mutableStateOf(updatedPageCount)
+    override val pageCount: Int
+        get() = pageCountState.value.invoke()
+
+    companion object {
+        /** To keep current page and current page offset saved */
+        val Saver: Saver<HomePagerState, *> =
+            listSaver(
+                save = {
+                    listOf(
+                        it.currentPage,
+                        (it.currentPageOffsetFraction).coerceIn(-0.5f, 0.5f),
+                        it.pageCount
+                    )
+                },
+                restore = {
+                    HomePagerState(
+                        currentPage = it[0] as Int,
+                        currentPageOffsetFraction = it[1] as Float,
+                        updatedPageCount = { it[2] as Int }
+                    )
+                }
+            )
+    }
+}

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/PagerState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/PagerState.kt
@@ -1,3 +1,20 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 package com.eblan.launcher.feature.home.component.pager
 
 import androidx.annotation.FloatRange
@@ -13,16 +30,16 @@ fun rememberHomePagerState(
     infiniteScroll: Boolean,
     initialPage: Int = 0,
     @FloatRange(from = -0.5, to = 0.5) initialPageOffsetFraction: Float = 0f,
-    pageCount: () -> Int
+    pageCount: () -> Int,
 ): PagerState {
     return rememberSaveable(
         infiniteScroll,
-        saver = DefaultPagerState.Saver
+        saver = DefaultPagerState.Saver,
     ) {
         DefaultPagerState(
             currentPage = initialPage,
             currentPageOffsetFraction = initialPageOffsetFraction,
-            updatedPageCount = pageCount
+            updatedPageCount = pageCount,
         )
     }
         .apply { pageCountState.value = pageCount }
@@ -31,7 +48,7 @@ fun rememberHomePagerState(
 private class DefaultPagerState(
     currentPage: Int,
     currentPageOffsetFraction: Float,
-    updatedPageCount: () -> Int
+    updatedPageCount: () -> Int,
 ) : PagerState(currentPage, currentPageOffsetFraction) {
 
     var pageCountState = mutableStateOf(updatedPageCount)
@@ -46,16 +63,16 @@ private class DefaultPagerState(
                     listOf(
                         it.currentPage,
                         (it.currentPageOffsetFraction).coerceIn(-0.5f, 0.5f),
-                        it.pageCount
+                        it.pageCount,
                     )
                 },
                 restore = {
                     DefaultPagerState(
                         currentPage = it[0] as Int,
                         currentPageOffsetFraction = it[1] as Float,
-                        updatedPageCount = { it[2] as Int }
+                        updatedPageCount = { it[2] as Int },
                     )
-                }
+                },
             )
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/PagerState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/pager/PagerState.kt
@@ -17,9 +17,9 @@ fun rememberHomePagerState(
 ): PagerState {
     return rememberSaveable(
         infiniteScroll,
-        saver = HomePagerState.Saver
+        saver = DefaultPagerState.Saver
     ) {
-        HomePagerState(
+        DefaultPagerState(
             currentPage = initialPage,
             currentPageOffsetFraction = initialPageOffsetFraction,
             updatedPageCount = pageCount
@@ -28,7 +28,7 @@ fun rememberHomePagerState(
         .apply { pageCountState.value = pageCount }
 }
 
-private class HomePagerState(
+private class DefaultPagerState(
     currentPage: Int,
     currentPageOffsetFraction: Float,
     updatedPageCount: () -> Int
@@ -40,7 +40,7 @@ private class HomePagerState(
 
     companion object {
         /** To keep current page and current page offset saved */
-        val Saver: Saver<HomePagerState, *> =
+        val Saver: Saver<DefaultPagerState, *> =
             listSaver(
                 save = {
                     listOf(
@@ -50,7 +50,7 @@ private class HomePagerState(
                     )
                 },
                 restore = {
-                    HomePagerState(
+                    DefaultPagerState(
                         currentPage = it[0] as Int,
                         currentPageOffsetFraction = it[1] as Float,
                         updatedPageCount = { it[2] as Int }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -134,7 +134,6 @@ fun DoubleTapApplicationScreen(
     gridItemSource: GridItemSource?,
     iconPackInfoPackageName: String,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -194,7 +193,6 @@ fun ApplicationScreen(
     gridItemSource: GridItemSource?,
     iconPackInfoPackageName: String,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -409,7 +407,6 @@ private fun EblanApplicationInfoDockSearchBar(
         intSize: IntSize,
     ) -> Unit,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -480,7 +477,6 @@ private fun EblanApplicationInfoItem(
         intSize: IntSize,
     ) -> Unit,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -632,7 +628,6 @@ private fun EblanApplicationInfoItem(
                                 )
 
                             onLongPressGridItem(
-                                page,
                                 GridItemSource.New(
                                     gridItem = GridItem(
                                         id = Uuid.random()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -110,7 +110,6 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.EblanApplicationComponentUiState
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.screen.loading.LoadingScreen
-import com.eblan.launcher.feature.home.util.calculatePage
 import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import kotlinx.coroutines.launch
@@ -123,8 +122,6 @@ import kotlin.uuid.Uuid
 fun DoubleTapApplicationScreen(
     modifier: Modifier = Modifier,
     currentPage: Int,
-    pageCount: Int,
-    infiniteScroll: Boolean,
     eblanApplicationComponentUiState: EblanApplicationComponentUiState,
     paddingValues: PaddingValues,
     drag: Drag,
@@ -155,8 +152,6 @@ fun DoubleTapApplicationScreen(
             IntOffset(x = 0, y = animatedSwipeUpY.value.roundToInt())
         },
         currentPage = currentPage,
-        pageCount = pageCount,
-        infiniteScroll = infiniteScroll,
         eblanApplicationComponentUiState = eblanApplicationComponentUiState,
         paddingValues = paddingValues,
         drag = drag,
@@ -183,8 +178,6 @@ fun DoubleTapApplicationScreen(
 fun ApplicationScreen(
     modifier: Modifier = Modifier,
     currentPage: Int,
-    pageCount: Int,
-    infiniteScroll: Boolean,
     eblanApplicationComponentUiState: EblanApplicationComponentUiState,
     paddingValues: PaddingValues,
     drag: Drag,
@@ -205,12 +198,6 @@ fun ApplicationScreen(
     val focusManager = LocalFocusManager.current
 
     var showPopupApplicationMenu by remember { mutableStateOf(false) }
-
-    val page = calculatePage(
-        index = currentPage,
-        infiniteScroll = infiniteScroll,
-        pageCount = pageCount,
-    )
 
     var popupMenuIntOffset by remember { mutableStateOf(IntOffset.Zero) }
 
@@ -278,7 +265,7 @@ fun ApplicationScreen(
                                     ),
                             ) {
                                 EblanApplicationInfoDockSearchBar(
-                                    page = page,
+                                    currentPage = currentPage,
                                     onQueryChange = onGetEblanApplicationInfosByLabel,
                                     eblanApplicationInfosByLabel = eblanApplicationInfosByLabel,
                                     drag = drag,
@@ -315,7 +302,7 @@ fun ApplicationScreen(
                                     ) {
                                         items(eblanApplicationInfos) { eblanApplicationInfo ->
                                             EblanApplicationInfoItem(
-                                                page = page,
+                                                currentPage = currentPage,
                                                 drag = drag,
                                                 eblanApplicationInfo = eblanApplicationInfo,
                                                 appDrawerSettings = appDrawerSettings,
@@ -395,7 +382,7 @@ fun ApplicationScreen(
 @Composable
 private fun EblanApplicationInfoDockSearchBar(
     modifier: Modifier = Modifier,
-    page: Int,
+    currentPage: Int,
     drag: Drag,
     appDrawerSettings: AppDrawerSettings,
     onQueryChange: (String) -> Unit,
@@ -446,7 +433,7 @@ private fun EblanApplicationInfoDockSearchBar(
         ) {
             items(eblanApplicationInfosByLabel) { eblanApplicationInfo ->
                 EblanApplicationInfoItem(
-                    page = page,
+                    currentPage = currentPage,
                     drag = drag,
                     eblanApplicationInfo = eblanApplicationInfo,
                     appDrawerSettings = appDrawerSettings,
@@ -466,7 +453,7 @@ private fun EblanApplicationInfoDockSearchBar(
 @Composable
 private fun EblanApplicationInfoItem(
     modifier: Modifier = Modifier,
-    page: Int,
+    currentPage: Int,
     drag: Drag,
     eblanApplicationInfo: EblanApplicationInfo,
     appDrawerSettings: AppDrawerSettings,
@@ -633,7 +620,7 @@ private fun EblanApplicationInfoItem(
                                         id = Uuid.random()
                                             .toHexString(),
                                         folderId = null,
-                                        page = page,
+                                        page = currentPage,
                                         startColumn = 0,
                                         startRow = 0,
                                         columnSpan = 1,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -54,7 +54,7 @@ suspend fun handlePageDirection(
 
 suspend fun handleDragIntOffset(
     density: Density,
-    targetPage: Int,
+    currentPage: Int,
     drag: Drag,
     gridItem: GridItem,
     dragIntOffset: IntOffset,
@@ -141,7 +141,7 @@ suspend fun handleDragIntOffset(
         val dockY = dragY - (gridHeight - dockHeight)
 
         val moveGridItem = getMoveGridItem(
-            targetPage = targetPage,
+            targetPage = currentPage,
             gridItem = gridItem,
             cellWidth = cellWidth,
             cellHeight = cellHeight,
@@ -186,7 +186,7 @@ suspend fun handleDragIntOffset(
         val cellHeight = gridHeightWithPadding / rows
 
         val moveGridItem = getMoveGridItem(
-            targetPage = targetPage,
+            targetPage = currentPage,
             gridItem = gridItem,
             cellWidth = cellWidth,
             cellHeight = cellHeight,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DropGridItemHelper.kt
@@ -33,7 +33,6 @@ import com.eblan.launcher.framework.widgetmanager.AndroidAppWidgetHostWrapper
 import com.eblan.launcher.framework.widgetmanager.AndroidAppWidgetManagerWrapper
 
 fun handleOnDragEnd(
-    targetPage: Int,
     moveGridItemResult: MoveGridItemResult?,
     androidAppWidgetHostWrapper: AndroidAppWidgetHostWrapper,
     appWidgetManager: AndroidAppWidgetManagerWrapper,
@@ -41,16 +40,15 @@ fun handleOnDragEnd(
     onDeleteGridItemCache: (GridItem) -> Unit,
     onLaunch: (Intent) -> Unit,
     onDragEndAfterMove: (
-        targetPage: Int,
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
-    onMoveGridItemsFailed: (Int) -> Unit,
+    onMoveGridItemsFailed: () -> Unit,
     onUpdateGridItemDataCache: (GridItem) -> Unit,
     onUpdateAppWidgetId: (Int) -> Unit,
 ) {
     if (moveGridItemResult == null || !moveGridItemResult.isSuccess) {
-        onMoveGridItemsFailed(targetPage)
+        onMoveGridItemsFailed()
 
         return
     }
@@ -74,7 +72,6 @@ fun handleOnDragEnd(
                 )
             } else {
                 onDragEndAfterMove(
-                    targetPage,
                     moveGridItemResult.movingGridItem,
                     moveGridItemResult.conflictingGridItem,
                 )
@@ -91,7 +88,6 @@ fun handleOnDragEnd(
                     )
 
                     onDragEndAfterMove(
-                        targetPage,
                         moveGridItemResult.movingGridItem,
                         moveGridItemResult.conflictingGridItem,
                     )
@@ -118,7 +114,6 @@ fun handleOnDragEnd(
 
         else -> {
             onDragEndAfterMove(
-                targetPage,
                 moveGridItemResult.movingGridItem,
                 moveGridItemResult.conflictingGridItem,
             )
@@ -150,14 +145,11 @@ fun handleConfigureResult(
     moveGridItemResult: MoveGridItemResult?,
     updatedGridItem: GridItem?,
     resultCode: Int,
-    targetPage: Int,
     onDeleteWidgetGridItemCache: (
-        targetPage: Int,
         gridItem: GridItem,
         appWidgetId: Int,
     ) -> Unit,
     onDragEndAfterMove: (
-        targetPage: Int,
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
@@ -170,11 +162,10 @@ fun handleConfigureResult(
         ?: error("Expected GridItemData as Widget")
 
     if (resultCode == Activity.RESULT_CANCELED) {
-        onDeleteWidgetGridItemCache(targetPage, updatedGridItem, data.appWidgetId)
+        onDeleteWidgetGridItemCache(updatedGridItem, data.appWidgetId)
     }
 
     onDragEndAfterMove(
-        targetPage,
         updatedGridItem,
         moveGridItemResult.conflictingGridItem,
     )
@@ -184,9 +175,7 @@ fun handleDeleteAppWidgetId(
     gridItem: GridItem,
     appWidgetId: Int,
     deleteAppWidgetId: Boolean,
-    targetPage: Int,
     onDeleteWidgetGridItemCache: (
-        targetPage: Int,
         gridItem: GridItem,
         appWidgetId: Int,
     ) -> Unit,
@@ -196,18 +185,16 @@ fun handleDeleteAppWidgetId(
     ) {
         check(gridItem.data is GridItemData.Widget)
 
-        onDeleteWidgetGridItemCache(targetPage, gridItem, appWidgetId)
+        onDeleteWidgetGridItemCache(gridItem, appWidgetId)
     }
 }
 
 fun handleBoundWidget(
     gridItemSource: GridItemSource,
     updatedGridItem: GridItem?,
-    targetPage: Int,
     moveGridItemResult: MoveGridItemResult?,
     onConfigure: (Intent) -> Unit,
     onDragEndAfterMove: (
-        targetPage: Int,
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
@@ -220,7 +207,6 @@ fun handleBoundWidget(
     when (gridItemSource) {
         is GridItemSource.New -> {
             configureComponent(
-                targetPage = targetPage,
                 appWidgetId = data.appWidgetId,
                 configure = data.configure,
                 updatedGridItem = updatedGridItem,
@@ -232,7 +218,6 @@ fun handleBoundWidget(
 
         is GridItemSource.Pin -> {
             bindPinWidget(
-                targetPage = targetPage,
                 appWidgetId = data.appWidgetId,
                 gridItem = updatedGridItem,
                 pinItemRequest = gridItemSource.pinItemRequest,
@@ -293,14 +278,12 @@ private fun onDragEndPinShortcut(
 }
 
 private fun configureComponent(
-    targetPage: Int,
     appWidgetId: Int,
     configure: String?,
     updatedGridItem: GridItem,
     conflictingGridItem: GridItem?,
     onConfigure: (Intent) -> Unit,
     onDragEndAfterMove: (
-        targetPage: Int,
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
@@ -317,7 +300,6 @@ private fun configureComponent(
         onConfigure(intent)
     } else {
         onDragEndAfterMove(
-            targetPage,
             updatedGridItem,
             conflictingGridItem,
         )
@@ -325,14 +307,12 @@ private fun configureComponent(
 }
 
 private fun bindPinWidget(
-    targetPage: Int,
     appWidgetId: Int,
     gridItem: GridItem,
     pinItemRequest: PinItemRequest,
     updatedGridItem: GridItem,
     conflictingGridItem: GridItem?,
     onDragEndAfterMove: (
-        targetPage: Int,
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
@@ -349,7 +329,6 @@ private fun bindPinWidget(
 
     if (bindPinWidget) {
         onDragEndAfterMove(
-            targetPage,
             updatedGridItem,
             conflictingGridItem,
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -76,9 +76,7 @@ fun FolderScreen(
     onUpdateScreen: (Screen) -> Unit,
     onRemoveLastFolder: () -> Unit,
     onAddFolder: (String) -> Unit,
-    onResetTargetPage: () -> Unit,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -119,8 +117,6 @@ fun FolderScreen(
 
     LaunchedEffect(key1 = foldersDataById) {
         if (foldersDataById.isEmpty()) {
-            onResetTargetPage()
-
             onUpdateScreen(Screen.Pager)
         }
     }
@@ -232,8 +228,6 @@ fun FolderScreen(
                                     )
                                 },
                                 onTapFolderGridItem = {
-                                    onResetTargetPage()
-
                                     onAddFolder(gridItem.id)
                                 },
                                 onLongPress = {
@@ -246,7 +240,6 @@ fun FolderScreen(
                                 },
                                 onUpdateImageBitmap = { imageBitmap ->
                                     onLongPressGridItem(
-                                        index,
                                         GridItemSource.Existing(gridItem = gridItem),
                                         imageBitmap,
                                     )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,7 +63,6 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 @Composable
 fun FolderScreen(
     modifier: Modifier = Modifier,
-    startCurrentPage: Int,
     foldersDataById: ArrayDeque<FolderDataById>,
     drag: Drag,
     paddingValues: PaddingValues,
@@ -73,6 +72,7 @@ fun FolderScreen(
     textColor: TextColor,
     homeSettings: HomeSettings,
     iconPackInfoPackageName: String,
+    folderGridHorizontalPagerState: PagerState,
     onUpdateScreen: (Screen) -> Unit,
     onRemoveLastFolder: () -> Unit,
     onAddFolder: (String) -> Unit,
@@ -146,13 +146,6 @@ fun FolderScreen(
                 ),
             targetState = folderDataById,
         ) { targetState ->
-            val horizontalPagerState = rememberPagerState(
-                initialPage = startCurrentPage,
-                pageCount = {
-                    folderDataById.pageCount
-                },
-            )
-
             Column(modifier = Modifier.fillMaxSize()) {
                 Column(
                     modifier = Modifier
@@ -173,7 +166,7 @@ fun FolderScreen(
                 }
 
                 HorizontalPager(
-                    state = horizontalPagerState,
+                    state = folderGridHorizontalPagerState,
                     modifier = Modifier.weight(1f),
                 ) { index ->
                     GridLayout(
@@ -270,8 +263,8 @@ fun FolderScreen(
                     modifier = Modifier
                         .height(pageIndicatorHeight)
                         .fillMaxWidth(),
-                    pageCount = horizontalPagerState.pageCount,
-                    currentPage = horizontalPagerState.currentPage,
+                    pageCount = folderGridHorizontalPagerState.pageCount,
+                    currentPage = folderGridHorizontalPagerState.currentPage,
                 )
             }
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragGridItemHelper.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.delay
 
 suspend fun handleFolderDragIntOffset(
     density: Density,
-    targetPage: Int,
+    currentPage: Int,
     drag: Drag,
     gridItem: GridItem,
     dragIntOffset: IntOffset,
@@ -123,7 +123,7 @@ suspend fun handleFolderDragIntOffset(
         val cellHeight = gridHeightWithPadding / rows
 
         val newGridItem = gridItem.copy(
-            page = targetPage,
+            page = currentPage,
             startColumn = gridX / cellWidth,
             startRow = gridY / cellHeight,
             associate = Associate.Grid,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,7 +68,6 @@ import kotlin.math.roundToInt
 @Composable
 fun FolderDragScreen(
     modifier: Modifier = Modifier,
-    startCurrentPage: Int,
     gridItemsCacheByPage: Map<Int, List<GridItem>>,
     gridItemSource: GridItemSource?,
     textColor: TextColor,
@@ -82,6 +81,7 @@ fun FolderDragScreen(
     iconPackInfoPackageName: String,
     hasShortcutHostPermission: Boolean,
     moveGridItemResult: MoveGridItemResult?,
+    folderGridHorizontalPagerState: PagerState,
     onMoveFolderGridItem: (
         movingGridItem: GridItem,
         x: Int,
@@ -115,17 +115,10 @@ fun FolderDragScreen(
         pageIndicatorHeight.roundToPx()
     }
 
-    val horizontalPagerState = rememberPagerState(
-        initialPage = startCurrentPage,
-        pageCount = {
-            folderDataById?.pageCount ?: 0
-        },
-    )
-
     LaunchedEffect(key1 = drag, key2 = dragIntOffset) {
         handleFolderDragIntOffset(
             density = density,
-            targetPage = horizontalPagerState.currentPage,
+            currentPage = folderGridHorizontalPagerState.currentPage,
             drag = drag,
             gridItem = gridItemSource.gridItem,
             dragIntOffset = dragIntOffset,
@@ -135,7 +128,7 @@ fun FolderDragScreen(
             pageIndicatorHeight = pageIndicatorHeightPx,
             columns = homeSettings.folderColumns,
             rows = homeSettings.folderRows,
-            isScrollInProgress = horizontalPagerState.isScrollInProgress,
+            isScrollInProgress = folderGridHorizontalPagerState.isScrollInProgress,
             paddingValues = paddingValues,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onMoveOutsideFolder = onMoveOutsideFolder,
@@ -147,10 +140,10 @@ fun FolderDragScreen(
 
     LaunchedEffect(key1 = pageDirection) {
         handlePageDirection(
-            currentPage = horizontalPagerState.currentPage,
+            currentPage = folderGridHorizontalPagerState.currentPage,
             pageDirection = pageDirection,
             onAnimateScrollToPage = { page ->
-                horizontalPagerState.animateScrollToPage(page = page)
+                folderGridHorizontalPagerState.animateScrollToPage(page = page)
 
                 pageDirection = null
             },
@@ -162,7 +155,7 @@ fun FolderDragScreen(
             Drag.End, Drag.Cancel -> {
                 handleOnDragEnd(
                     density = density,
-                    currentPage = horizontalPagerState.currentPage,
+                    currentPage = folderGridHorizontalPagerState.currentPage,
                     dragIntOffset = dragIntOffset,
                     screenHeight = screenHeight,
                     gridPadding = gridPadding,
@@ -186,7 +179,7 @@ fun FolderDragScreen(
             ),
     ) {
         HorizontalPager(
-            state = horizontalPagerState,
+            state = folderGridHorizontalPagerState,
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(
                 top = horizontalPagerPaddingDp,
@@ -231,13 +224,13 @@ fun FolderDragScreen(
             modifier = Modifier
                 .height(pageIndicatorHeight)
                 .fillMaxWidth(),
-            pageCount = horizontalPagerState.pageCount,
-            currentPage = horizontalPagerState.currentPage,
+            pageCount = folderGridHorizontalPagerState.pageCount,
+            currentPage = folderGridHorizontalPagerState.currentPage,
         )
     }
 
     AnimatedDropGridItem(
-        targetPage = horizontalPagerState.currentPage,
+        targetPage = folderGridHorizontalPagerState.currentPage,
         gridPadding = gridPadding,
         screenWidth = screenWidth,
         screenHeight = screenHeight,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
@@ -91,7 +91,7 @@ fun FolderDragScreen(
         gridWidth: Int,
         gridHeight: Int,
     ) -> Unit,
-    onDragEnd: (Int) -> Unit,
+    onDragEnd: () -> Unit,
     onDragCancel: () -> Unit,
     onMoveOutsideFolder: (GridItemSource) -> Unit,
 ) {
@@ -155,7 +155,6 @@ fun FolderDragScreen(
             Drag.End, Drag.Cancel -> {
                 handleOnDragEnd(
                     density = density,
-                    currentPage = folderGridHorizontalPagerState.currentPage,
                     dragIntOffset = dragIntOffset,
                     screenHeight = screenHeight,
                     gridPadding = gridPadding,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDropGridItemHelper.kt
@@ -23,13 +23,12 @@ import androidx.compose.ui.unit.IntOffset
 
 fun handleOnDragEnd(
     density: Density,
-    currentPage: Int,
     dragIntOffset: IntOffset,
     screenHeight: Int,
     gridPadding: Int,
     pageIndicatorHeight: Int,
     paddingValues: PaddingValues,
-    onDragEnd: (Int) -> Unit,
+    onDragEnd: () -> Unit,
     onDragCancel: () -> Unit,
 ) {
     val topPadding = with(density) {
@@ -53,7 +52,7 @@ fun handleOnDragEnd(
     val isVerticalBounds = !isOnTopGrid && !isOnBottomGrid
 
     if (isVerticalBounds) {
-        onDragEnd(currentPage)
+        onDragEnd()
     } else {
         onDragCancel()
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -120,7 +120,7 @@ fun PagerScreen(
     onTapFolderGridItem: (String) -> Unit,
     onDraggingGridItem: () -> Unit,
     onEdit: (String) -> Unit,
-    onResize: (Int) -> Unit,
+    onResize: () -> Unit,
     onSettings: () -> Unit,
     onEditPage: (List<GridItem>) -> Unit,
     onLongPressGridItem: (
@@ -200,7 +200,7 @@ fun PagerScreen(
                             (Int.MAX_VALUE / 2) + homeSettings.initialPage
                         } else {
                             homeSettings.initialPage
-                        }
+                        },
                     )
                 }
             }
@@ -495,7 +495,7 @@ private fun HorizontalPagerScreen(
     iconPackInfoPackageName: String,
     onTapFolderGridItem: (String) -> Unit,
     onEdit: (String) -> Unit,
-    onResize: (Int) -> Unit,
+    onResize: () -> Unit,
     onSettings: () -> Unit,
     onEditPage: (List<GridItem>) -> Unit,
     onWidgets: () -> Unit,
@@ -783,7 +783,6 @@ private fun HorizontalPagerScreen(
 
     if (showPopupGridItemMenu && gridItemSource?.gridItem != null) {
         PopupGridItemMenu(
-            currentPage = currentPage,
             gridItem = gridItemSource.gridItem,
             x = popupMenuIntOffset.x,
             y = popupMenuIntOffset.y,
@@ -892,14 +891,13 @@ private fun PopupSettingsMenu(
 
 @Composable
 private fun PopupGridItemMenu(
-    currentPage: Int,
     gridItem: GridItem,
     x: Int,
     y: Int,
     width: Int,
     height: Int,
     onEdit: (String) -> Unit,
-    onResize: (Int) -> Unit,
+    onResize: () -> Unit,
     onUninstallApplicationInfo: (String) -> Unit,
     onDeleteGridItem: (GridItem) -> Unit,
     onInfo: (String?) -> Unit,
@@ -923,7 +921,7 @@ private fun PopupGridItemMenu(
                             onDismissRequest()
                         },
                         onResize = {
-                            onResize(currentPage)
+                            onResize()
 
                             onDismissRequest()
                         },
@@ -953,7 +951,7 @@ private fun PopupGridItemMenu(
                             onDismissRequest()
                         },
                         onResize = {
-                            onResize(currentPage)
+                            onResize()
 
                             onDismissRequest()
                         },
@@ -973,7 +971,7 @@ private fun PopupGridItemMenu(
                             onDismissRequest()
                         },
                         onResize = {
-                            onResize(currentPage)
+                            onResize()
 
                             onDismissRequest()
                         },
@@ -991,7 +989,7 @@ private fun PopupGridItemMenu(
                     WidgetGridItemMenu(
                         showResize = showResize,
                         onResize = {
-                            onResize(currentPage)
+                            onResize()
                         },
                         onDelete = {
                             onDeleteGridItem(gridItem)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -305,9 +305,7 @@ fun PagerScreen(
             modifier = Modifier.offset {
                 IntOffset(x = 0, y = applicationComponentY.roundToInt())
             },
-            currentPage = gridHorizontalPagerState.currentPage,
-            pageCount = homeSettings.pageCount,
-            infiniteScroll = homeSettings.infiniteScroll,
+            currentPage = currentPage,
             eblanApplicationComponentUiState = eblanApplicationComponentUiState,
             paddingValues = paddingValues,
             drag = drag,
@@ -354,10 +352,8 @@ fun PagerScreen(
 
             GestureAction.OpenAppDrawer -> {
                 DoubleTapApplicationScreen(
-                    currentPage = gridHorizontalPagerState.currentPage,
+                    currentPage = currentPage,
                     eblanApplicationComponentUiState = eblanApplicationComponentUiState,
-                    pageCount = homeSettings.pageCount,
-                    infiniteScroll = homeSettings.infiniteScroll,
                     paddingValues = paddingValues,
                     drag = drag,
                     screenHeight = screenHeight,
@@ -435,9 +431,7 @@ fun PagerScreen(
 
     if (showWidgets) {
         WidgetScreen(
-            currentPage = gridHorizontalPagerState.currentPage,
-            pageCount = homeSettings.pageCount,
-            infiniteScroll = homeSettings.infiniteScroll,
+            currentPage = currentPage,
             eblanApplicationComponentUiState = eblanApplicationComponentUiState,
             gridItemSettings = homeSettings.gridItemSettings,
             paddingValues = paddingValues,
@@ -456,9 +450,7 @@ fun PagerScreen(
 
     if (showShortcuts) {
         ShortcutScreen(
-            currentPage = gridHorizontalPagerState.currentPage,
-            pageCount = homeSettings.pageCount,
-            infiniteScroll = homeSettings.infiniteScroll,
+            currentPage = currentPage,
             eblanApplicationComponentUiState = eblanApplicationComponentUiState,
             gridItemSettings = homeSettings.gridItemSettings,
             paddingValues = paddingValues,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
@@ -239,7 +239,7 @@ private fun EblanShortcutInfoDockSearchBar(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
@@ -309,7 +309,7 @@ private fun EblanApplicationInfoItem(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
@@ -382,7 +382,7 @@ private fun EblanShortcutInfoItem(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
@@ -101,7 +101,6 @@ fun ShortcutScreen(
     drag: Drag,
     eblanShortcutInfosByLabel: Map<EblanApplicationInfo, List<EblanShortcutInfo>>,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -238,7 +237,10 @@ private fun EblanShortcutInfoDockSearchBar(
     eblanShortcutInfosByLabel: Map<EblanApplicationInfo, List<EblanShortcutInfo>>,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -305,7 +307,10 @@ private fun EblanApplicationInfoItem(
     eblanShortcutInfos: Map<EblanApplicationInfo, List<EblanShortcutInfo>>,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -375,7 +380,10 @@ private fun EblanShortcutInfoItem(
     eblanShortcutInfo: EblanShortcutInfo,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -452,7 +460,6 @@ private fun EblanShortcutInfoItem(
                                 )
 
                                 onLongPressGridItem(
-                                    page,
                                     GridItemSource.New(
                                         gridItem = GridItem(
                                             id = eblanShortcutInfo.shortcutId,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcut/ShortcutScreen.kt
@@ -84,7 +84,6 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.EblanApplicationComponentUiState
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.screen.loading.LoadingScreen
-import com.eblan.launcher.feature.home.util.calculatePage
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -92,8 +91,6 @@ import kotlin.math.roundToInt
 fun ShortcutScreen(
     modifier: Modifier = Modifier,
     currentPage: Int,
-    pageCount: Int,
-    infiniteScroll: Boolean,
     eblanApplicationComponentUiState: EblanApplicationComponentUiState,
     gridItemSettings: GridItemSettings,
     paddingValues: PaddingValues,
@@ -109,12 +106,6 @@ fun ShortcutScreen(
     onDismiss: () -> Unit,
     onDraggingGridItem: () -> Unit,
 ) {
-    val page = calculatePage(
-        index = currentPage,
-        infiniteScroll = infiniteScroll,
-        pageCount = pageCount,
-    )
-
     val animatedSwipeUpY = remember { Animatable(screenHeight.toFloat()) }
 
     val scope = rememberCoroutineScope()
@@ -197,7 +188,7 @@ fun ShortcutScreen(
                                     drag = drag,
                                     onUpdateGridItemOffset = onUpdateGridItemOffset,
                                     onLongPressGridItem = onLongPressGridItem,
-                                    page = page,
+                                    currentPage = currentPage,
                                     gridItemSettings = gridItemSettings,
                                     onDraggingGridItem = onDraggingGridItem,
                                 )
@@ -214,7 +205,7 @@ fun ShortcutScreen(
                                             drag = drag,
                                             onUpdateGridItemOffset = onUpdateGridItemOffset,
                                             onLongPressGridItem = onLongPressGridItem,
-                                            page = page,
+                                            currentPage = currentPage,
                                             gridItemSettings = gridItemSettings,
                                             onDraggingGridItem = onDraggingGridItem,
                                         )
@@ -241,7 +232,7 @@ private fun EblanShortcutInfoDockSearchBar(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -291,7 +282,7 @@ private fun EblanShortcutInfoDockSearchBar(
                         onUpdateGridItemOffset(intOffset)
                     },
                     onLongPressGridItem = onLongPressGridItem,
-                    page = page,
+                    currentPage = currentPage,
                     gridItemSettings = gridItemSettings,
                     onDraggingGridItem = onDraggingGridItem,
                 )
@@ -311,7 +302,7 @@ private fun EblanApplicationInfoItem(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -365,7 +356,7 @@ private fun EblanApplicationInfoItem(
                     drag = drag,
                     onUpdateGridItemOffset = onUpdateGridItemOffset,
                     onLongPressGridItem = onLongPressGridItem,
-                    page = page,
+                    currentPage = currentPage,
                     gridItemSettings = gridItemSettings,
                     onDraggingGridItem = onDraggingGridItem,
                 )
@@ -384,7 +375,7 @@ private fun EblanShortcutInfoItem(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -464,7 +455,7 @@ private fun EblanShortcutInfoItem(
                                         gridItem = GridItem(
                                             id = eblanShortcutInfo.shortcutId,
                                             folderId = null,
-                                            page = page,
+                                            page = currentPage,
                                             startColumn = 0,
                                             startRow = 0,
                                             columnSpan = 1,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -235,7 +235,7 @@ private fun EblanAppWidgetProviderInfoDockSearchBar(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
@@ -300,7 +300,7 @@ private fun EblanApplicationInfoItem(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
@@ -374,7 +374,7 @@ private fun EblanAppWidgetProviderInfoItem(
     onUpdateGridItemOffset: (IntOffset) -> Unit,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
-        imageBitmap: ImageBitmap?
+        imageBitmap: ImageBitmap?,
     ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -84,7 +84,6 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.EblanApplicationComponentUiState
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.screen.loading.LoadingScreen
-import com.eblan.launcher.feature.home.util.calculatePage
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.uuid.ExperimentalUuidApi
@@ -94,8 +93,6 @@ import kotlin.uuid.Uuid
 fun WidgetScreen(
     modifier: Modifier = Modifier,
     currentPage: Int,
-    pageCount: Int,
-    infiniteScroll: Boolean,
     eblanApplicationComponentUiState: EblanApplicationComponentUiState,
     gridItemSettings: GridItemSettings,
     paddingValues: PaddingValues,
@@ -111,12 +108,6 @@ fun WidgetScreen(
     onDismiss: () -> Unit,
     onDraggingGridItem: () -> Unit,
 ) {
-    val page = calculatePage(
-        index = currentPage,
-        infiniteScroll = infiniteScroll,
-        pageCount = pageCount,
-    )
-
     val animatedSwipeUpY = remember { Animatable(screenHeight.toFloat()) }
 
     val scope = rememberCoroutineScope()
@@ -193,7 +184,7 @@ fun WidgetScreen(
                                     drag = drag,
                                     onUpdateGridItemOffset = onUpdateGridItemOffset,
                                     onLongPressGridItem = onLongPressGridItem,
-                                    page = page,
+                                    currentPage = currentPage,
                                     gridItemSettings = gridItemSettings,
                                     onDraggingGridItem = onDraggingGridItem,
                                 )
@@ -210,7 +201,7 @@ fun WidgetScreen(
                                             drag = drag,
                                             onUpdateGridItemOffset = onUpdateGridItemOffset,
                                             onLongPressGridItem = onLongPressGridItem,
-                                            page = page,
+                                            currentPage = currentPage,
                                             gridItemSettings = gridItemSettings,
                                             onDraggingGridItem = onDraggingGridItem,
                                         )
@@ -237,7 +228,7 @@ private fun EblanAppWidgetProviderInfoDockSearchBar(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -282,7 +273,7 @@ private fun EblanAppWidgetProviderInfoDockSearchBar(
                         onUpdateGridItemOffset(intOffset)
                     },
                     onLongPressGridItem = onLongPressGridItem,
-                    page = page,
+                    currentPage = currentPage,
                     gridItemSettings = gridItemSettings,
                     onDraggingGridItem = onDraggingGridItem,
                 )
@@ -302,7 +293,7 @@ private fun EblanApplicationInfoItem(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -356,7 +347,7 @@ private fun EblanApplicationInfoItem(
                     drag = drag,
                     onUpdateGridItemOffset = onUpdateGridItemOffset,
                     onLongPressGridItem = onLongPressGridItem,
-                    page = page,
+                    currentPage = currentPage,
                     gridItemSettings = gridItemSettings,
                     onDraggingGridItem = onDraggingGridItem,
                 )
@@ -376,7 +367,7 @@ private fun EblanAppWidgetProviderInfoItem(
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
-    page: Int,
+    currentPage: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
 ) {
@@ -448,7 +439,7 @@ private fun EblanAppWidgetProviderInfoItem(
                                         gridItem = getWidgetGridItem(
                                             id = Uuid.random()
                                                 .toHexString(),
-                                            page = page,
+                                            page = currentPage,
                                             componentName = eblanAppWidgetProviderInfo.componentName,
                                             configure = eblanAppWidgetProviderInfo.configure,
                                             packageName = eblanAppWidgetProviderInfo.packageName,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -103,7 +103,6 @@ fun WidgetScreen(
     drag: Drag,
     eblanAppWidgetProviderInfosByLabel: Map<EblanApplicationInfo, List<EblanAppWidgetProviderInfo>>,
     onLongPressGridItem: (
-        currentPage: Int,
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
     ) -> Unit,
@@ -234,7 +233,10 @@ private fun EblanAppWidgetProviderInfoDockSearchBar(
     eblanAppWidgetProviderInfosByLabel: Map<EblanApplicationInfo, List<EblanAppWidgetProviderInfo>>,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -296,7 +298,10 @@ private fun EblanApplicationInfoItem(
     eblanAppWidgetProviderInfos: Map<EblanApplicationInfo, List<EblanAppWidgetProviderInfo>>,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -367,7 +372,10 @@ private fun EblanAppWidgetProviderInfoItem(
     eblanAppWidgetProviderInfo: EblanAppWidgetProviderInfo,
     drag: Drag,
     onUpdateGridItemOffset: (IntOffset) -> Unit,
-    onLongPressGridItem: (currentPage: Int, gridItemSource: GridItemSource, imageBitmap: ImageBitmap?) -> Unit,
+    onLongPressGridItem: (
+        gridItemSource: GridItemSource,
+        imageBitmap: ImageBitmap?
+    ) -> Unit,
     page: Int,
     gridItemSettings: GridItemSettings,
     onDraggingGridItem: () -> Unit,
@@ -436,7 +444,6 @@ private fun EblanAppWidgetProviderInfoItem(
                                 scale.animateTo(1f)
 
                                 onLongPressGridItem(
-                                    page,
                                     GridItemSource.New(
                                         gridItem = getWidgetGridItem(
                                             id = Uuid.random()


### PR DESCRIPTION
This commit refactors page handling within the home feature by removing the `currentPage` parameter from several composables and callbacks. The current page is now derived from a shared `PagerState` managed in `HomeScreen`. A new `rememberHomePagerState` composable has been introduced to create and remember this `PagerState`.

- **ApplicationScreen.kt, ShortcutScreen.kt, WidgetScreen.kt:**
    - Removed `currentPage` parameter from `onLongPressGridItem` callback.
- **PagerScreen.kt:**
    - Removed `targetPage` parameter.
    - Removed `onLongPressGrid` callback.
    - `onTapFolderGridItem` and `onLongPressGridItem` callbacks no longer take `currentPage` as a parameter.
    - `HorizontalPagerScreen` now accepts `gridHorizontalPagerState: PagerState` and `currentPage: Int` instead of managing its own `PagerState`.
    - Removed local `currentPage` calculation based on `horizontalPagerState`.
- **DragGridItemHelper.kt:**
    - `handleDragIntOffset` now accepts `currentPage: Int` instead of `targetPage: Int`.
- **DropGridItemHelper.kt:**
    - Removed `targetPage` parameter from `handleOnDragEnd`, `handleConfigureResult`, `handleDeleteAppWidgetId`, `handleBoundWidget`, `configureComponent`, and `bindPinWidget`.
    - Callbacks like `onDragEndAfterMove`, `onMoveGridItemsFailed`, and `onDeleteWidgetGridItemCache` no longer receive `targetPage`.
- **component/pager/HomePagerState.kt:**
    - New file created with `rememberHomePagerState` composable function. This function creates and remembers a `PagerState` instance, taking into account infinite scrolling and initial page settings.
- **DragScreen.kt:**
    - Removed `startCurrentPage` parameter.
    - Now accepts `gridHorizontalPagerState: PagerState` and `currentPage: Int` instead of creating its own `PagerState`.
    - Updated calls to `handleDragIntOffset`, `handlePageDirection`, `handleOnDragEnd`, `handleDeleteAppWidgetId`, `handleBoundWidget`, and `AnimatedDropGridItem` to use the new `currentPage` or remove the page parameter where it's no longer needed.
    - Callbacks `onDragEndAfterMove`, `onMoveGridItemsFailed`, and `onDeleteWidgetGridItemCache` no longer receive `targetPage`.
- **HomeScreen.kt:**
    - Removed `targetPage` mutable state.
    - Introduced `gridHorizontalPagerState` using the new `rememberHomePagerState`.
    - Introduced `currentPage` derived from `gridHorizontalPagerState`.
    - Updated calls to `PagerScreen`, `DragScreen`, and `ResizeScreen` to pass `gridHorizontalPagerState` and `currentPage`.
    - Simplified callbacks like `onLongPressGridItem`, `onTapFolderGridItem`, `onDragEndAfterMove`, `onMoveGridItemsFailed`, and `onDeleteWidgetGridItemCache` by removing page parameters.