### PR TITLE
Fix: Correct resize screen layout and prevent crash

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -634,7 +634,8 @@ private fun Success(
 
             Screen.Resize -> {
                 ResizeScreen(
-                    gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage[currentPage],
+                    currentPage = currentPage,
+                    gridItemsCacheByPage = gridItemsCache.gridItemsCacheByPage[currentPage].orEmpty(),
                     gridItem = gridItemSource?.gridItem,
                     screenWidth = screenWidth,
                     screenHeight = screenHeight,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
@@ -38,6 +38,7 @@ import com.eblan.launcher.domain.model.HomeSettings
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.component.grid.GridItemContent
 import com.eblan.launcher.feature.home.component.grid.GridLayout
+import com.eblan.launcher.feature.home.component.pageindicator.PageIndicator
 import com.eblan.launcher.feature.home.component.resize.GridItemResizeOverlay
 import com.eblan.launcher.feature.home.component.resize.WidgetGridItemResizeOverlay
 import com.eblan.launcher.feature.home.util.getGridItemTextColor
@@ -46,7 +47,8 @@ import com.eblan.launcher.feature.home.util.getSystemTextColor
 @Composable
 fun ResizeScreen(
     modifier: Modifier = Modifier,
-    gridItemsCacheByPage: List<GridItem>?,
+    currentPage: Int,
+    gridItemsCacheByPage: List<GridItem>,
     gridItem: GridItem?,
     screenWidth: Int,
     screenHeight: Int,
@@ -65,8 +67,6 @@ fun ResizeScreen(
     onResizeCancel: () -> Unit,
 ) {
     requireNotNull(gridItem)
-
-    requireNotNull(gridItemsCacheByPage)
 
     val density = LocalDensity.current
 
@@ -100,6 +100,12 @@ fun ResizeScreen(
         dockHeight.roundToPx()
     }
 
+    val pageIndicatorHeight = 20.dp
+
+    val pageIndicatorHeightPx = with(density) {
+        pageIndicatorHeight.roundToPx()
+    }
+
     BackHandler {
         onResizeCancel()
     }
@@ -110,9 +116,7 @@ fun ResizeScreen(
             .padding(paddingValues),
     ) {
         GridLayout(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
+            modifier = Modifier.weight(1f),
             gridItems = gridItemsCacheByPage,
             columns = homeSettings.columns,
             rows = homeSettings.rows,
@@ -126,6 +130,14 @@ fun ResizeScreen(
                     hasShortcutHostPermission = hasShortcutHostPermission,
                 )
             },
+        )
+
+        PageIndicator(
+            modifier = Modifier
+                .height(pageIndicatorHeight)
+                .fillMaxWidth(),
+            pageCount = homeSettings.pageCount,
+            currentPage = currentPage,
         )
 
         GridLayout(
@@ -152,7 +164,7 @@ fun ResizeScreen(
         Associate.Grid -> {
             val cellWidth = gridWidth / homeSettings.columns
 
-            val cellHeight = (gridHeight - dockHeightPx) / homeSettings.rows
+            val cellHeight = (gridHeight - pageIndicatorHeightPx - dockHeightPx) / homeSettings.rows
 
             val x = gridItem.startColumn * cellWidth
 


### PR DESCRIPTION
This commit fixes a layout issue on the resize screen and prevents a potential crash caused by an empty grid item cache.

- **`feature/home/HomeScreen.kt`**:
  - A call to `orEmpty()` is added when accessing `gridItemsCache.gridItemsCacheByPage`. This prevents a `NullPointerException` if a page has no items, making the resize functionality more robust.

- **`feature/home/screen/resize/ResizeScreen.kt`**:
  - The `PageIndicator` is now included on the resize screen, ensuring layout consistency with the main home screen.
  - The height calculation for grid cells (`cellHeight`) has been adjusted to account for the space occupied by the newly added `PageIndicator`, preventing items from overlapping with the dock.
  - The `gridItemsCacheByPage` parameter is no longer nullable, as this is now safely handled by the `orEmpty()` call in `HomeScreen`.
  
  Closes #253 