### PR TITLE
Perf: Reduce delay in drag and resize operations

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/GridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/GridItemResizeOverlay.kt
@@ -252,7 +252,7 @@ fun GridItemResizeOverlay(
                 rows = rows,
             )
         ) {
-            delay(250L)
+            delay(100L)
 
             onResizeGridItem(
                 resizingGridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/WidgetGridItemResizeOverlay.kt
@@ -139,7 +139,7 @@ fun WidgetGridItemResizeOverlay(
         .background(color = color, shape = CircleShape)
 
     LaunchedEffect(key1 = currentWidth, key2 = currentHeight) {
-        delay(250L)
+        delay(100L)
 
         val allowedWidth = if (data.minResizeWidth > 0 && currentWidth <= data.minResizeWidth) {
             data.minResizeWidth
@@ -219,8 +219,6 @@ fun WidgetGridItemResizeOverlay(
                 rows = rows,
             )
         ) {
-            delay(250L)
-
             onResizeWidgetGridItem(
                 resizingGridItem,
                 columns,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -82,7 +82,7 @@ suspend fun handleDragGridItem(
         gridHeight: Int,
     ) -> Unit,
 ) {
-    delay(250L)
+    delay(100L)
 
     if (drag != Drag.Dragging || isScrollInProgress) {
         return

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/DragFolderGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/DragFolderGridItemHelper.kt
@@ -57,7 +57,7 @@ suspend fun handleDragFolderGridItem(
     ) -> Unit,
     onMoveOutsideFolder: (GridItemSource) -> Unit,
 ) {
-    delay(250L)
+    delay(100L)
 
     if (drag != Drag.Dragging || isScrollInProgress) {
         return


### PR DESCRIPTION
This commit reduces the `delay` from 250ms to 100ms across several drag-and-drop and resizing helpers. This change makes the user interface feel more responsive during these interactions.

Closes #286 

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt`**:
  - Decreased the delay before processing grid item drag actions.

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/DragFolderGridItemHelper.kt`**:
  - Reduced the delay for drag operations within folders.

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/GridItemResizeOverlay.kt`**:
  - Shortened the debounce delay for grid item resize operations.

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/resize/WidgetGridItemResizeOverlay.kt`**:
  - Lowered the debounce delay for widget resizing, improving feedback speed.
  - Removed a redundant `delay(250L)` from the resize confirmation logic.