### PR TITLE
Feat: Exclude overridden items from grid item updates

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateApplicationInfoGridItemsByPackageNameUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateApplicationInfoGridItemsByPackageNameUseCase.kt
@@ -53,7 +53,9 @@ class UpdateApplicationInfoGridItemsByPackageNameUseCase @Inject constructor(
                         launcherAppsActivityInfo.packageName == packageName
                 }
 
-            applicationInfoGridItems.forEach { applicationInfoGridItem ->
+            applicationInfoGridItems.filterNot { applicationInfoGridItem ->
+                applicationInfoGridItem.override
+            }.forEach { applicationInfoGridItem ->
                 val launcherAppsActivityInfo =
                     launcherAppsActivityInfos.find { launcherAppsActivityInfo ->
                         launcherAppsActivityInfo.packageName == applicationInfoGridItem.packageName &&

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateApplicationInfoGridItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateApplicationInfoGridItemsUseCase.kt
@@ -45,7 +45,9 @@ class UpdateApplicationInfoGridItemsUseCase @Inject constructor(
 
             val launcherAppsActivityInfos = launcherAppsWrapper.getActivityList()
 
-            applicationInfoGridItems.forEach { applicationInfoGridItem ->
+            applicationInfoGridItems.filterNot { applicationInfoGridItem ->
+                applicationInfoGridItem.override
+            }.forEach { applicationInfoGridItem ->
                 ensureActive()
 
                 val launcherAppsActivityInfo =

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateShortcutInfoGridItemsByPackageNameUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateShortcutInfoGridItemsByPackageNameUseCase.kt
@@ -56,7 +56,9 @@ class UpdateShortcutInfoGridItemsByPackageNameUseCase @Inject constructor(
             )
 
             if (launcherAppsShortcutInfos != null) {
-                shortcutInfoGridItems.forEach { shortcutInfoGridItem ->
+                shortcutInfoGridItems.filterNot { shortcutInfoGridItem ->
+                    shortcutInfoGridItem.override
+                }.forEach { shortcutInfoGridItem ->
                     val launcherAppsShortcutInfo =
                         launcherAppsShortcutInfos.find { launcherAppsShortcutInfo ->
                             launcherAppsShortcutInfo.shortcutId == shortcutInfoGridItem.shortcutId &&

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateShortcutInfoGridItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateShortcutInfoGridItemsUseCase.kt
@@ -49,7 +49,9 @@ class UpdateShortcutInfoGridItemsUseCase @Inject constructor(
             val launcherAppsShortcutInfos = launcherAppsWrapper.getPinnedShortcuts()
 
             if (launcherAppsShortcutInfos != null) {
-                shortcutInfoGridItems.forEach { shortcutInfoGridItem ->
+                shortcutInfoGridItems.filterNot { shortcutInfoGridItem ->
+                    shortcutInfoGridItem.override
+                }.forEach { shortcutInfoGridItem ->
                     ensureActive()
 
                     val launcherAppsShortcutInfo =

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateWidgetGridItemsByPackageNameUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateWidgetGridItemsByPackageNameUseCase.kt
@@ -54,7 +54,9 @@ class UpdateWidgetGridItemsByPackageNameUseCase @Inject constructor(
                         appWidgetManagerAppWidgetProviderInfo.packageName == packageName
                     }
 
-            widgetGridItems.forEach { widgetGridItem ->
+            widgetGridItems.filterNot { widgetGridItem ->
+                widgetGridItem.override
+            }.forEach { widgetGridItem ->
                 val appWidgetManagerAppWidgetProviderInfo =
                     appWidgetManagerAppWidgetProviderInfos
                         .find { appWidgetManagerAppWidgetProviderInfo ->

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateWidgetGridItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/UpdateWidgetGridItemsUseCase.kt
@@ -50,7 +50,9 @@ class UpdateWidgetGridItemsUseCase @Inject constructor(
             val appWidgetManagerAppWidgetProviderInfos =
                 appWidgetManagerWrapper.getInstalledProviders()
 
-            widgetGridItems.forEach { widgetGridItem ->
+            widgetGridItems.filterNot { widgetGridItem ->
+                widgetGridItem.override
+            }.forEach { widgetGridItem ->
                 ensureActive()
 
                 val appWidgetManagerAppWidgetProviderInfo =


### PR DESCRIPTION
This commit enhances the grid item update logic to prevent user-customized items from being automatically updated. Items with the `override` flag set to `true` are now filtered out before the update process begins.

Closes #292 

- **`UpdateApplicationInfoGridItemsUseCase.kt`**
- **`UpdateShortcutInfoGridItemsUseCase.kt`**
- **`UpdateWidgetGridItemsUseCase.kt`**
- **`UpdateApplicationInfoGridItemsByPackageNameUseCase.kt`**
- **`UpdateShortcutInfoGridItemsByPackageNameUseCase.kt`**
- **`UpdateWidgetGridItemsByPackageNameUseCase.kt`**:
    - In each use case, a `.filterNot { it.override }` is added to the grid item collection. This ensures that any application, shortcut, or widget that has been manually edited (and thus has `override == true`) is skipped during system-wide or package-specific updates, preserving user changes.