### PR TITLE
Refactor: Respect per-item override settings for grid items

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -2,3 +2,4 @@
 - Perf: Reduce delay in drag and resize operations
 - Fix: Re-calculate current page when home settings change
 - Perf: Make long-running loops cancellable
+- Refactor: Respect per-item override settings for grid items

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/grid/GridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/grid/GridItem.kt
@@ -53,10 +53,7 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.GridItemSettings
 import com.eblan.launcher.domain.model.HorizontalAlignment
-import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.domain.model.VerticalArrangement
-import com.eblan.launcher.feature.home.util.getGridItemTextColor
-import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalAppWidgetHost
 import com.eblan.launcher.ui.local.LocalAppWidgetManager
 import java.io.File
@@ -65,35 +62,20 @@ import java.io.File
 fun GridItemContent(
     modifier: Modifier = Modifier,
     gridItem: GridItem,
-    textColor: TextColor,
+    textColor: Color,
     gridItemSettings: GridItemSettings,
     iconPackInfoPackageName: String,
     isDragging: Boolean,
     hasShortcutHostPermission: Boolean,
 ) {
     key(gridItem.id) {
-        val currentGridItemSettings = if (gridItem.override) {
-            gridItem.gridItemSettings
-        } else {
-            gridItemSettings
-        }
-
-        val currentTextColor = if (gridItem.override) {
-            getGridItemTextColor(
-                systemTextColor = textColor,
-                gridItemTextColor = gridItem.gridItemSettings.textColor,
-            )
-        } else {
-            getSystemTextColor(textColor = textColor)
-        }
-
         if (isDragging) {
             Box(
                 modifier = modifier
                     .fillMaxSize()
                     .border(
                         width = Dp.Hairline,
-                        color = currentTextColor,
+                        color = textColor,
                         shape = RoundedCornerShape(5.dp),
                     ),
             )
@@ -103,8 +85,8 @@ fun GridItemContent(
                     ApplicationInfoGridItem(
                         modifier = modifier,
                         data = data,
-                        textColor = currentTextColor,
-                        gridItemSettings = currentGridItemSettings,
+                        textColor = textColor,
+                        gridItemSettings = gridItemSettings,
                         iconPackInfoPackageName = iconPackInfoPackageName,
                     )
                 }
@@ -120,8 +102,8 @@ fun GridItemContent(
                     ShortcutInfoGridItem(
                         modifier = modifier,
                         data = data,
-                        textColor = currentTextColor,
-                        gridItemSettings = currentGridItemSettings,
+                        textColor = textColor,
+                        gridItemSettings = gridItemSettings,
                         hasShortcutHostPermission = hasShortcutHostPermission,
                     )
                 }
@@ -130,8 +112,8 @@ fun GridItemContent(
                     FolderGridItem(
                         modifier = modifier,
                         data = data,
-                        textColor = currentTextColor,
-                        gridItemSettings = currentGridItemSettings,
+                        textColor = textColor,
+                        gridItemSettings = gridItemSettings,
                         iconPackInfoPackageName = iconPackInfoPackageName,
                     )
                 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
@@ -122,10 +122,25 @@ fun ResizeScreen(
             columns = homeSettings.columns,
             rows = homeSettings.rows,
             { gridItem ->
+                val gridItemSettings = if (gridItem.override) {
+                    gridItem.gridItemSettings
+                } else {
+                    homeSettings.gridItemSettings
+                }
+
+                val textColor = if (gridItem.override) {
+                    getGridItemTextColor(
+                        systemTextColor = textColor,
+                        gridItemTextColor = gridItem.gridItemSettings.textColor,
+                    )
+                } else {
+                    getSystemTextColor(textColor = textColor)
+                }
+
                 GridItemContent(
                     gridItem = gridItem,
                     textColor = textColor,
-                    gridItemSettings = homeSettings.gridItemSettings,
+                    gridItemSettings = gridItemSettings,
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     isDragging = false,
                     hasShortcutHostPermission = hasShortcutHostPermission,
@@ -149,10 +164,25 @@ fun ResizeScreen(
             columns = homeSettings.dockColumns,
             rows = homeSettings.dockRows,
             { gridItem ->
+                val gridItemSettings = if (gridItem.override) {
+                    gridItem.gridItemSettings
+                } else {
+                    homeSettings.gridItemSettings
+                }
+
+                val textColor = if (gridItem.override) {
+                    getGridItemTextColor(
+                        systemTextColor = textColor,
+                        gridItemTextColor = gridItem.gridItemSettings.textColor,
+                    )
+                } else {
+                    getSystemTextColor(textColor = textColor)
+                }
+
                 GridItemContent(
                     gridItem = gridItem,
                     textColor = textColor,
-                    gridItemSettings = homeSettings.gridItemSettings,
+                    gridItemSettings = gridItemSettings,
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     isDragging = false,
                     hasShortcutHostPermission = hasShortcutHostPermission,


### PR DESCRIPTION
This commit refactors how individual grid item settings (like icon size, text size, and text color) are handled, ensuring that per-item overrides are correctly applied across different screens.

Closes #294 

Previously, the logic to determine whether to use global or item-specific settings was duplicated and incorrectly handled in some places. This has been centralized and corrected.

- **`feature/home/component/grid/GridItem.kt`**:
  - The logic for selecting between global `gridItemSettings` and an item's overridden settings has been removed from `GridItemContent`. This composable now receives the final, resolved settings and color, simplifying its responsibility.

- **`feature/home/screen/drag/DragScreen.kt` & `feature/home/screen/folderdrag/FolderDragScreen.kt`**:
  - Logic has been added to correctly resolve `gridItemSettings` and `textColor` for each grid item.
  - This ensures that items being dragged, as well as static items in the background grid, respect their `override` flag and display with their custom settings.

- **`feature/home/screen/resize/ResizeScreen.kt`**:
  - Similar to the drag screens, logic is added to resolve `gridItemSettings` and `textColor` for each item, ensuring they render correctly with their potential override settings during resize mode.