### PR TITLE
Fix: Prevent item span from exceeding grid boundaries

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -638,7 +638,7 @@ private fun Success(
                     overlayIntSize = overlayIntSize,
                     onMoveGridItem = onMoveGridItem,
                     onDragEndAfterMove = onResetGridCacheAfterMove,
-                    onMoveGridItemsFailed = onCancelGridCache,
+                    onDragCancelAfterMove = onCancelGridCache,
                     onDeleteGridItemCache = onDeleteGridItemCache,
                     onUpdateGridItemDataCache = onUpdateGridItemDataCache,
                     onDeleteWidgetGridItemCache = onDeleteWidgetGridItemCache,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -286,12 +286,12 @@ private fun getMoveNewGridItem(
     return when (val data = gridItem.data) {
         is GridItemData.Widget -> {
             val (checkedColumnSpan, checkedRowSpan) = getWidgetGridItemSpan(
-                cellHeight = cellHeight,
                 cellWidth = cellWidth,
-                minHeight = data.minHeight,
+                cellHeight = cellHeight,
                 minWidth = data.minWidth,
-                targetCellHeight = data.targetCellHeight,
+                minHeight = data.minHeight,
                 targetCellWidth = data.targetCellWidth,
+                targetCellHeight = data.targetCellHeight,
             )
 
             val (checkedMinWidth, checkedMinHeight) = getWidgetGridItemSize(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -18,6 +18,7 @@
 package com.eblan.launcher.feature.home.screen.drag
 
 import android.appwidget.AppWidgetManager
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.Animatable
@@ -48,6 +49,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
@@ -113,7 +115,7 @@ fun DragScreen(
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
-    onMoveGridItemsFailed: () -> Unit,
+    onDragCancelAfterMove: () -> Unit,
     onDeleteGridItemCache: (GridItem) -> Unit,
     onUpdateGridItemDataCache: (GridItem) -> Unit,
     onDeleteWidgetGridItemCache: (
@@ -123,6 +125,8 @@ fun DragScreen(
     onResetOverlay: () -> Unit,
 ) {
     requireNotNull(gridItemSource)
+
+    val context = LocalContext.current
 
     val appWidgetHostWrapper = LocalAppWidgetHost.current
 
@@ -251,7 +255,15 @@ fun DragScreen(
                     gridItemSource = gridItemSource,
                     onLaunch = appWidgetLauncher::launch,
                     onDragEndAfterMove = onDragEndAfterMove,
-                    onMoveGridItemsFailed = onMoveGridItemsFailed,
+                    onDragCancelAfterMove = {
+                        Toast.makeText(
+                            context,
+                            "Can't place grid item at this position",
+                            Toast.LENGTH_LONG,
+                        ).show()
+
+                        onDragCancelAfterMove()
+                    },
                     onDeleteGridItemCache = onDeleteGridItemCache,
                     onUpdateGridItemDataCache = { gridItem ->
                         updatedGridItem = gridItem
@@ -267,7 +279,7 @@ fun DragScreen(
             }
 
             Drag.Cancel -> {
-                onMoveGridItemsFailed()
+                onDragCancelAfterMove()
 
                 onResetOverlay()
             }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DropGridItemHelper.kt
@@ -44,12 +44,12 @@ fun handleDropGridItem(
         movingGridItem: GridItem,
         conflictingGridItem: GridItem?,
     ) -> Unit,
-    onMoveGridItemsFailed: () -> Unit,
+    onDragCancelAfterMove: () -> Unit,
     onUpdateGridItemDataCache: (GridItem) -> Unit,
     onUpdateAppWidgetId: (Int) -> Unit,
 ) {
     if (moveGridItemResult == null || !moveGridItemResult.isSuccess) {
-        onMoveGridItemsFailed()
+        onDragCancelAfterMove()
 
         return
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.eblan.launcher.feature.home.screen.folderdrag
 
+import android.widget.Toast
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector2D
 import androidx.compose.animation.core.TwoWayConverter
@@ -43,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
@@ -102,6 +104,8 @@ fun FolderDragScreen(
     onResetOverlay: () -> Unit,
 ) {
     requireNotNull(gridItemSource)
+
+    val context = LocalContext.current
 
     val density = LocalDensity.current
 
@@ -182,7 +186,15 @@ fun FolderDragScreen(
                     pageIndicatorHeight = pageIndicatorHeightPx,
                     paddingValues = paddingValues,
                     onDragEnd = onDragEnd,
-                    onDragCancel = onDragCancel,
+                    onDragCancel = {
+                        Toast.makeText(
+                            context,
+                            "Can't place grid item at this position",
+                            Toast.LENGTH_LONG,
+                        ).show()
+
+                        onDragCancel()
+                    },
                 )
 
                 onResetOverlay()


### PR DESCRIPTION
This commit prevents a bug that occurs when a dragged item's span (width or height) is larger than the grid's dimensions. It ensures that the `columnSpan` and `rowSpan` are coerced to be within the valid range of the grid's columns and rows.
Closes #272
Closes #301

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt`**:
    - `columnSpan` is now clamped to a minimum of 1 and a maximum of the total grid `columns`.
    - `rowSpan` is now clamped to a minimum of 1 and a maximum of the total grid `rows`.