### PR TITLE
Feat: Conditionally show GridItemSettings in EditScreen

### DIFF
--- a/feature/edit/src/main/kotlin/com/eblan/launcher/feature/edit/EditScreen.kt
+++ b/feature/edit/src/main/kotlin/com/eblan/launcher/feature/edit/EditScreen.kt
@@ -164,14 +164,16 @@ private fun Success(
             },
         )
 
-        Spacer(modifier = Modifier.height(10.dp))
+        if (gridItem.override) {
+            Spacer(modifier = Modifier.height(10.dp))
 
-        GridItemSettings(
-            gridItemSettings = gridItem.gridItemSettings,
-            onUpdateGridItemSettings = { gridItemSettings ->
-                onUpdateGridItem(gridItem.copy(gridItemSettings = gridItemSettings))
-            },
-        )
+            GridItemSettings(
+                gridItemSettings = gridItem.gridItemSettings,
+                onUpdateGridItemSettings = { gridItemSettings ->
+                    onUpdateGridItem(gridItem.copy(gridItemSettings = gridItemSettings))
+                },
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This commit updates the `EditShortcutInfo` composable to conditionally display the `GridItemSettings` section.
Closes #303

- **`feature/edit/src/main/kotlin/com/eblan/launcher/feature/edit/EditScreen.kt`**:
    - The `GridItemSettings` composable will now only be rendered if the `gridItem.override` property is `true`. This prevents users from modifying settings for items that do not have override properties enabled.