### PR TITLE
Refactor: Centralize overscroll and fling logic

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/scroll/OffsetNestedScrollConnection.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/scroll/OffsetNestedScrollConnection.kt
@@ -1,0 +1,74 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.home.component.scroll
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class OffsetNestedScrollConnection(
+    private val scope: CoroutineScope,
+    private val overscrollAlpha: Animatable<Float, AnimationVector1D>,
+    private val overscrollOffset: Animatable<Float, AnimationVector1D>,
+    private val overscrollFactor: Float,
+    private val onFling: suspend () -> Unit,
+    private val onFastFling: suspend () -> Unit,
+) : NestedScrollConnection {
+    override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource,
+    ): Offset {
+        scope.launch {
+            if (available.y > 0) {
+                val newOverscrollValue =
+                    overscrollOffset.value + (available.y * overscrollFactor)
+
+                overscrollOffset.snapTo(newOverscrollValue)
+
+                overscrollAlpha.snapTo(newOverscrollValue)
+            } else {
+                val newOverscrollValue =
+                    overscrollOffset.value + (available.y * overscrollFactor)
+
+                overscrollOffset.snapTo(newOverscrollValue)
+
+                overscrollAlpha.snapTo(newOverscrollValue)
+            }
+        }
+
+        return super.onPostScroll(consumed, available, source)
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+        handleOnFling(
+            remaining = available - consumed,
+            overscrollAlpha = overscrollAlpha,
+            overscrollOffset = overscrollOffset,
+            onFastFling = onFastFling,
+            onFling = onFling,
+        )
+
+        return super.onPostFling(consumed, available)
+    }
+}

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/scroll/Scroll.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/scroll/Scroll.kt
@@ -1,0 +1,53 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.home.component.scroll
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.ui.unit.Velocity
+
+internal suspend fun handleOnFling(
+    remaining: Velocity,
+    overscrollAlpha: Animatable<Float, AnimationVector1D>,
+    overscrollOffset: Animatable<Float, AnimationVector1D>,
+    onFastFling: suspend () -> Unit,
+    onFling: suspend () -> Unit,
+) {
+    overscrollAlpha.snapTo(0f)
+
+    if (overscrollOffset.value <= 0f && remaining.y > 10000f) {
+        overscrollOffset.snapTo(0f)
+
+        onFastFling()
+    } else if (overscrollOffset.value > 500f) {
+        overscrollOffset.snapTo(0f)
+
+        onFling()
+    } else {
+        overscrollOffset.animateTo(
+            targetValue = 0f,
+            initialVelocity = remaining.y,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessLow,
+            ),
+        )
+    }
+}

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -48,7 +48,7 @@ import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.EblanAppWidgetProviderInfo
 import com.eblan.launcher.domain.model.EblanAppWidgetProviderInfoByGroup
 import com.eblan.launcher.domain.model.GridItemSettings
-import com.eblan.launcher.feature.home.component.overscroll.OffsetOverscrollEffect
+import com.eblan.launcher.feature.home.component.scroll.OffsetOverscrollEffect
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.EblanApplicationComponentUiState
 import com.eblan.launcher.feature.home.model.GridItemSource


### PR DESCRIPTION
This commit refactors the overscroll and fling handling logic by centralizing it into a new `handleOnFling` function and introducing an `OffsetNestedScrollConnection` for use when native overscroll is not available.

Closes #156 

- **`feature/home/component/scroll/Scroll.kt`**:
    - New file containing a reusable `handleOnFling` function. This function encapsulates the logic for determining whether a fling is a "fast fling," a regular "fling," or should animate back to its resting state.

- **`feature/home/component/scroll/OffsetNestedScrollConnection.kt`**:
    - New `NestedScrollConnection` implementation that consumes scroll and fling events.
    - It uses the centralized `handleOnFling` function to manage fling gestures, making overscroll behavior consistent.

- **`feature/home/screen/application/EblanApplicationInfosPage.kt`**:
    - Now conditionally applies `nestedScroll` with the new `OffsetNestedScrollConnection` only when the content is not large enough to scroll (`canOverscroll` is false).
    - When the content is scrollable, it continues to use the `OffsetOverscrollEffect`, which now also uses the `handleOnFling` logic.
    - This ensures a consistent pull-to-dismiss gesture regardless of whether the app list fills the screen.

- **`feature/home/component/scroll/OffsetOverscrollEffect.kt`**:
    - The file has been moved from `component/overscroll` to `component/scroll`.
    - Fling handling logic has been extracted into the new `handleOnFling` function.
    - The overscroll factor is now reduced when scrolling upwards (pulling down) to create a more resistant feel.