### PR TITLE
Fix: Prevent drag detection when popup menu is closed

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -190,7 +190,7 @@ private fun Success(
     }
 
     LaunchedEffect(key1 = drag) {
-        if (isApplicationComponentVisible) {
+        if (isApplicationComponentVisible && showPopupApplicationMenu) {
             when (drag) {
                 Drag.Dragging -> {
                     onDraggingGridItem()


### PR DESCRIPTION
This commit fixes an issue where drag events were being processed even when the application popup menu was not visible.

Closes #321

- **`feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt`**:
    - The `LaunchedEffect` that handles drag gestures now includes a `showPopupApplicationMenu` check. This ensures that drag detection is only active when both the application component is visible and the popup menu is open, preventing unintended drag actions.