### PR TITLE
Refactor: Removed Dragging/Resizing delay

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -71,6 +71,7 @@ internal suspend fun handleDragGridItem(
     isScrollInProgress: Boolean,
     gridItemSource: GridItemSource,
     paddingValues: PaddingValues,
+    lastGridItem: GridItem?,
     onUpdatePageDirection: (PageDirection) -> Unit,
     onMoveGridItem: (
         movingGridItem: GridItem,
@@ -81,9 +82,8 @@ internal suspend fun handleDragGridItem(
         gridWidth: Int,
         gridHeight: Int,
     ) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
-    delay(100L)
-
     if (drag != Drag.Dragging || isScrollInProgress) {
         return
     }
@@ -134,93 +134,114 @@ internal suspend fun handleDragGridItem(
 
     val isOnDock = dragY > (gridHeight - dockHeightPx)
 
-    if (isOnLeftGrid && isVerticalBounds) {
-        onUpdatePageDirection(PageDirection.Left)
-    } else if (isOnRightGrid && isVerticalBounds) {
-        onUpdatePageDirection(PageDirection.Right)
-    } else if (isOnDock) {
-        val cellWidth = gridWidth / dockColumns
+    when {
+        isOnLeftGrid && isVerticalBounds -> {
+            delay(100L)
 
-        val cellHeight = dockHeightPx / dockRows
-
-        val dockY = dragY - (gridHeight - dockHeightPx)
-
-        val moveGridItem = getMoveGridItem(
-            targetPage = currentPage,
-            gridItem = gridItem,
-            cellWidth = cellWidth,
-            cellHeight = cellHeight,
-            columns = dockColumns,
-            rows = dockRows,
-            gridWidth = gridWidth,
-            gridHeight = dockHeightPx,
-            gridX = dragX,
-            gridY = dockY,
-            associate = Associate.Dock,
-            gridItemSource = gridItemSource,
-        )
-
-        val isGridItemSpanWithinBounds = isGridItemSpanWithinBounds(
-            gridItem = moveGridItem,
-            columns = dockColumns,
-            rows = dockRows,
-        )
-
-        if (isGridItemSpanWithinBounds) {
-            onMoveGridItem(
-                moveGridItem,
-                dragX,
-                dockY,
-                dockColumns,
-                dockRows,
-                gridWidth,
-                dockHeightPx,
-            )
+            onUpdatePageDirection(PageDirection.Left)
         }
-    } else if (isHorizontalBounds && isVerticalBounds) {
-        val gridWidthWithPadding = gridWidth - (gridPadding * 2)
 
-        val gridHeightWithPadding = (gridHeight - pageIndicatorHeight - dockHeightPx) - (gridPadding * 2)
+        isOnRightGrid && isVerticalBounds -> {
+            delay(100L)
 
-        val gridX = dragX - gridPadding
+            onUpdatePageDirection(PageDirection.Right)
+        }
 
-        val gridY = dragY - gridPadding
+        isOnDock -> {
+            val cellWidth = gridWidth / dockColumns
 
-        val cellWidth = gridWidthWithPadding / columns
+            val cellHeight = dockHeightPx / dockRows
 
-        val cellHeight = gridHeightWithPadding / rows
+            val dockY = dragY - (gridHeight - dockHeightPx)
 
-        val moveGridItem = getMoveGridItem(
-            targetPage = currentPage,
-            gridItem = gridItem,
-            cellWidth = cellWidth,
-            cellHeight = cellHeight,
-            columns = columns,
-            rows = rows,
-            gridWidth = gridWidthWithPadding,
-            gridHeight = gridHeightWithPadding,
-            gridX = gridX,
-            gridY = gridY,
-            associate = Associate.Grid,
-            gridItemSource = gridItemSource,
-        )
-
-        val isGridItemSpanWithinBounds = isGridItemSpanWithinBounds(
-            gridItem = moveGridItem,
-            columns = columns,
-            rows = rows,
-        )
-
-        if (isGridItemSpanWithinBounds) {
-            onMoveGridItem(
-                moveGridItem,
-                gridX,
-                gridY,
-                columns,
-                rows,
-                gridWidthWithPadding,
-                gridHeightWithPadding,
+            val moveGridItem = getMoveGridItem(
+                targetPage = currentPage,
+                gridItem = gridItem,
+                cellWidth = cellWidth,
+                cellHeight = cellHeight,
+                columns = dockColumns,
+                rows = dockRows,
+                gridWidth = gridWidth,
+                gridHeight = dockHeightPx,
+                gridX = dragX,
+                gridY = dockY,
+                associate = Associate.Dock,
+                gridItemSource = gridItemSource,
             )
+
+            val isGridItemSpanWithinBounds = isGridItemSpanWithinBounds(
+                gridItem = moveGridItem,
+                columns = dockColumns,
+                rows = dockRows,
+            )
+
+            if (isGridItemSpanWithinBounds &&
+                moveGridItem != lastGridItem
+            ) {
+                onMoveGridItem(
+                    moveGridItem,
+                    dragX,
+                    dockY,
+                    dockColumns,
+                    dockRows,
+                    gridWidth,
+                    dockHeightPx,
+                )
+
+                onUpdateGridItem(moveGridItem)
+            }
+        }
+
+        isHorizontalBounds && isVerticalBounds -> {
+            val gridWidthWithPadding = gridWidth - (gridPadding * 2)
+
+            val gridHeightWithPadding =
+                (gridHeight - pageIndicatorHeight - dockHeightPx) - (gridPadding * 2)
+
+            val gridX = dragX - gridPadding
+
+            val gridY = dragY - gridPadding
+
+            val cellWidth = gridWidthWithPadding / columns
+
+            val cellHeight = gridHeightWithPadding / rows
+
+            val moveGridItem = getMoveGridItem(
+                targetPage = currentPage,
+                gridItem = gridItem,
+                cellWidth = cellWidth,
+                cellHeight = cellHeight,
+                columns = columns,
+                rows = rows,
+                gridWidth = gridWidthWithPadding,
+                gridHeight = gridHeightWithPadding,
+                gridX = gridX,
+                gridY = gridY,
+                associate = Associate.Grid,
+                gridItemSource = gridItemSource,
+            )
+
+            val isGridItemSpanWithinBounds = isGridItemSpanWithinBounds(
+                gridItem = moveGridItem,
+                columns = columns,
+                rows = rows,
+            )
+
+            if (isGridItemSpanWithinBounds &&
+                moveGridItem != lastGridItem
+            ) {
+                onMoveGridItem(
+                    moveGridItem,
+                    gridX,
+                    gridY,
+                    columns,
+                    rows,
+                    gridWidthWithPadding,
+                    gridHeightWithPadding,
+                )
+
+                onUpdateGridItem(moveGridItem)
+            }
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -170,6 +170,8 @@ internal fun DragScreen(
 
     var updatedWidgetGridItem by remember { mutableStateOf<GridItem?>(null) }
 
+    var lastGridItem by remember { mutableStateOf<GridItem?>(null) }
+
     val dockHeight = homeSettings.dockHeight.dp
 
     val gridHorizontalPagerPaddingDp = 50.dp
@@ -280,10 +282,14 @@ internal fun DragScreen(
             isScrollInProgress = gridHorizontalPagerState.isScrollInProgress,
             gridItemSource = gridItemSource,
             paddingValues = paddingValues,
+            lastGridItem = lastGridItem,
             onUpdatePageDirection = { newPageDirection ->
                 pageDirection = newPageDirection
             },
             onMoveGridItem = onMoveGridItem,
+            onUpdateGridItem = { gridItem ->
+                lastGridItem = gridItem
+            },
         )
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
@@ -44,7 +44,6 @@ import com.eblan.launcher.domain.grid.resizeGridItemWithPixels
 import com.eblan.launcher.domain.model.Anchor
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.feature.home.model.Drag
-import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
 @Composable
@@ -62,12 +61,14 @@ internal fun GridItemResizeOverlay(
     width: Int,
     height: Int,
     color: Color,
+    lastGridItem: GridItem?,
     onResizeGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val density = LocalDensity.current
 
@@ -250,15 +251,15 @@ internal fun GridItemResizeOverlay(
                 gridItem = resizingGridItem,
                 columns = columns,
                 rows = rows,
-            )
+            ) && resizingGridItem != lastGridItem
         ) {
-            delay(100L)
-
             onResizeGridItem(
                 resizingGridItem,
                 columns,
                 rows,
             )
+
+            onUpdateGridItem(resizingGridItem)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
@@ -27,6 +27,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.LayoutDirection
@@ -104,6 +108,8 @@ internal fun ResizeScreen(
     val pageIndicatorHeightPx = with(density) {
         pageIndicatorHeight.roundToPx()
     }
+
+    var lastGridItem by remember { mutableStateOf<GridItem?>(null) }
 
     BackHandler {
         onResizeCancel()
@@ -222,8 +228,12 @@ internal fun ResizeScreen(
                 width = width,
                 height = height,
                 textColor = textColor,
+                lastGridItem = lastGridItem,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
+                onUpdateGridItem = { gridItem ->
+                    lastGridItem = gridItem
+                },
             )
         }
 
@@ -257,8 +267,12 @@ internal fun ResizeScreen(
                 width = width,
                 height = height,
                 textColor = textColor,
+                lastGridItem = lastGridItem,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
+                onUpdateGridItem = { gridItem ->
+                    lastGridItem = gridItem
+                },
             )
         }
     }
@@ -278,12 +292,14 @@ private fun ResizeOverlay(
     width: Int,
     height: Int,
     textColor: TextColor,
+    lastGridItem: GridItem?,
     onResizeGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val currentTextColor = if (gridItem.override) {
         getGridItemTextColor(
@@ -313,8 +329,10 @@ private fun ResizeOverlay(
                 width = width,
                 height = height,
                 color = currentTextColor,
+                lastGridItem = lastGridItem,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
 
@@ -331,8 +349,10 @@ private fun ResizeOverlay(
                 width = width,
                 height = height,
                 color = currentTextColor,
+                lastGridItem = lastGridItem,
                 onResizeWidgetGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
@@ -46,7 +46,6 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.SideAnchor
 import com.eblan.launcher.feature.home.model.Drag
-import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
 @Composable
@@ -63,12 +62,14 @@ internal fun WidgetGridItemResizeOverlay(
     width: Int,
     height: Int,
     color: Color,
+    lastGridItem: GridItem?,
     onResizeWidgetGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val density = LocalDensity.current
 
@@ -139,8 +140,6 @@ internal fun WidgetGridItemResizeOverlay(
         .background(color = color, shape = CircleShape)
 
     LaunchedEffect(key1 = currentWidth, key2 = currentHeight) {
-        delay(100L)
-
         val allowedWidth = if (data.minResizeWidth > 0 && currentWidth <= data.minResizeWidth) {
             data.minResizeWidth
         } else if (data.maxResizeWidth in 1..<currentWidth) {
@@ -217,13 +216,15 @@ internal fun WidgetGridItemResizeOverlay(
                 gridItem = resizingGridItem,
                 columns = columns,
                 rows = rows,
-            )
+            ) && resizingGridItem != lastGridItem
         ) {
             onResizeWidgetGridItem(
                 resizingGridItem,
                 columns,
                 rows,
             )
+
+            onUpdateGridItem(resizingGridItem)
         }
     }
 


### PR DESCRIPTION
Closes #372 

This commit optimizes the performance of dragging and resizing grid items by preventing unnecessary recompositions. The `delay()` function has been removed from the resize and drag logic to make the user experience smoother and more responsive.

A new state, `lastGridItem`, is introduced to track the most recently moved or resized item. The system now only triggers a recomposition if the new grid item's state is different from the last one, significantly reducing redundant UI updates during drag and resize operations.

- **`feature/home`**:
    - **`screen/drag/DragGridItemHelper.kt`**: - Removed a `100L` delay to make dragging more immediate. - Introduced a check to ensure `onMoveGridItem` is only called if the `moveGridItem` is different from the `lastGridItem`, preventing rapid-fire updates. - The `onUpdatePageDirection` call is now delayed to avoid overly sensitive page switching.
    - **`screen/resize/GridItemResizeOverlay.kt` & `WidgetGridItemResizeOverlay.kt`**:
        - Removed a `100L` delay from the resize `LaunchedEffect`.
        - A new `onUpdateGridItem` callback updates `lastGridItem` after a resize. - The `onResizeGridItem` and `onResizeWidgetGridItem` functions are now only invoked if the `resizingGridItem` differs from `lastGridItem`.
    - **`screen/drag/DragScreen.kt` & `screen/resize/ResizeScreen.kt`**: - Added `lastGridItem` state and the corresponding `onUpdateGridItem` callback, which are passed down to the helper composables.