### PR TITLE
Fix: AppDrawer Overscroll Bug

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -194,7 +194,6 @@ internal fun ApplicationScreen(
                     gridItemSource = gridItemSource,
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     eblanApplicationInfos = eblanApplicationComponentUiState.eblanApplicationComponent.eblanApplicationInfos,
-                    offsetY = offsetY,
                     onLongPressGridItem = onLongPressGridItem,
                     onUpdateGridItemOffset = onUpdateGridItemOffset,
                     onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
@@ -222,7 +221,6 @@ private fun Success(
     gridItemSource: GridItemSource?,
     iconPackInfoPackageName: String,
     eblanApplicationInfos: Map<Long, List<EblanApplicationInfo>>,
-    offsetY: () -> Float,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
@@ -334,7 +332,6 @@ private fun Success(
                     appDrawerSettings = appDrawerSettings,
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     eblanApplicationInfos = eblanApplicationInfos,
-                    offsetY = offsetY,
                     onLongPressGridItem = onLongPressGridItem,
                     onResetOverlay = onResetOverlay,
                     onUpdateGridItemOffset = { intOffset, intSize ->
@@ -360,7 +357,6 @@ private fun Success(
                 appDrawerSettings = appDrawerSettings,
                 iconPackInfoPackageName = iconPackInfoPackageName,
                 eblanApplicationInfos = eblanApplicationInfos,
-                offsetY = offsetY,
                 onLongPressGridItem = onLongPressGridItem,
                 onResetOverlay = onResetOverlay,
                 onUpdateGridItemOffset = { intOffset, intSize ->
@@ -716,7 +712,6 @@ private fun EblanApplicationInfosPage(
     appDrawerSettings: AppDrawerSettings,
     iconPackInfoPackageName: String,
     eblanApplicationInfos: Map<Long, List<EblanApplicationInfo>>,
-    offsetY: () -> Float,
     onLongPressGridItem: (
         gridItemSource: GridItemSource,
         imageBitmap: ImageBitmap?,
@@ -730,9 +725,11 @@ private fun EblanApplicationInfosPage(
     onVerticalDrag: (Float) -> Unit,
     onDragEnd: (Float) -> Unit,
 ) {
-    val overscrollEffect = remember {
+    val scope = rememberCoroutineScope()
+
+    val overscrollEffect = remember(key1 = scope) {
         OffsetOverscrollEffect(
-            offsetY = offsetY,
+            scope = scope,
             onVerticalDrag = onVerticalDrag,
             onDragEnd = onDragEnd,
         )


### PR DESCRIPTION
Closes #339 

This commit refactors the overscroll handling for bottom sheet-style screens (`ApplicationScreen`, `WidgetScreen`, `ShortcutConfigScreen`) by centralizing state management within the `OffsetOverscrollEffect` class.

Previously, each screen managed its own `offsetY` state and passed callbacks and values down to the `OffsetOverscrollEffect`. This created a dependency on the parent composable for state handling.

Now, `OffsetOverscrollEffect` manages its own internal `Animatable` offset state. It accepts a `CoroutineScope` and exposes `onVerticalDrag` and `onDragEnd` callbacks, which are implemented by the parent screen to handle snapping, animation, and dismissal logic. This change decouples the overscroll effect from the screen's vertical offset state, making the component more self-contained and reusable. The `offsetY` parameter has been removed from several composables as it is no longer needed.

- **`feature/home/component/scroll/OffsetOverscrollEffect.kt`**:
  - The class now holds an internal `Animatable` for the overscroll offset, removing the need to pass in an `offsetY` value.
  - It takes a `CoroutineScope` to launch state updates.
  - State updates are now performed within the effect itself, simplifying the logic in the calling composables.

- **`feature/home/screen/application/ApplicationScreen.kt`**:
  - The `offsetY` parameter has been removed from `ApplicationListComponent` and its nested composables as it was no longer used.
  - `OffsetOverscrollEffect` is now initialized with a `CoroutineScope`.

- **`feature/home/screen/widget/WidgetScreen.kt`**:
  - `BackHandler` logic has been moved from the `WidgetList` composable up to the main `WidgetScreen` for better consistency and to prevent dismissal from a child component.
  - Removed the `offsetY`, `screenHeight`, and `onDismiss` parameters from `WidgetList` as the drag and dismissal logic is now handled at the `WidgetScreen` level.

- **`feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt`**:
  - The `BackHandler` has been moved from the nested pages to the main `ShortcutConfigScreen` composable to properly handle dismissal animations.
  - Removed `offsetY`, `screenHeight`, and `onDismiss` parameters from child composables (`EblanShortcutConfigsList`, `EblanShortcutConfigsPage`). The vertical drag and dismissal logic is now handled by the parent screen.