### PR TITLE
Refactor: Clean up styling in DragScreen

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.animation.core.AnimationVector2D
 import androidx.compose.animation.core.TwoWayConverter
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -40,6 +39,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -172,7 +172,7 @@ internal fun DragScreen(
 
     val dockHeight = homeSettings.dockHeight.dp
 
-    val gridHorizontalPagerPaddingDp = 50.dp
+    val gridHorizontalPagerPaddingDp = 30.dp
 
     val gridPaddingDp = 8.dp
 
@@ -406,12 +406,7 @@ internal fun DragScreen(
                     .fillMaxSize()
                     .padding(gridPaddingDp)
                     .background(
-                        color = getSystemTextColor(textColor = textColor).copy(alpha = 0.25f),
-                        shape = RoundedCornerShape(8.dp),
-                    )
-                    .border(
-                        width = 2.dp,
-                        color = getSystemTextColor(textColor = textColor),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
                         shape = RoundedCornerShape(8.dp),
                     ),
                 gridItems = gridItemCache.gridItemsCacheByPage[page],
@@ -549,11 +544,7 @@ private fun AnimatedDropGridItem(
     gridItemSource: GridItemSource,
     statusBarNotifications: Map<String, Int>,
 ) {
-    if (drag != Drag.End ||
-        moveGridItemResult?.isSuccess != true ||
-        moveGridItemResult.movingGridItem.page != currentPage ||
-        gridItemSource is GridItemSource.Pin
-    ) {
+    if (drag != Drag.End || moveGridItemResult?.isSuccess != true || moveGridItemResult.movingGridItem.page != currentPage || gridItemSource is GridItemSource.Pin) {
         return
     }
 
@@ -639,8 +630,7 @@ private fun AnimatedDropGridItem(
 
             val cellHeight = dockHeightPx / dockRows
 
-            targetX =
-                (moveGridItemResult.movingGridItem.startColumn * cellWidth) + leftPadding
+            targetX = (moveGridItemResult.movingGridItem.startColumn * cellWidth) + leftPadding
 
             targetY =
                 (moveGridItemResult.movingGridItem.startRow * cellHeight) + (screenHeight - bottomPadding - dockHeightPx)
@@ -655,11 +645,9 @@ private fun AnimatedDropGridItem(
 
     val animatedY = remember { Animatable(overlayIntOffset.y.toFloat()) }
 
-    val animatedWidth =
-        remember { Animatable(overlayIntSize.width.toFloat()) }
+    val animatedWidth = remember { Animatable(overlayIntSize.width.toFloat()) }
 
-    val animatedHeight =
-        remember { Animatable(overlayIntSize.height.toFloat()) }
+    val animatedHeight = remember { Animatable(overlayIntSize.height.toFloat()) }
 
     val animatedAlpha = remember { Animatable(1f) }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -39,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -146,13 +146,7 @@ internal fun EditPageScreen(
                 ) {
                     OutlinedCard(
                         colors = CardDefaults.cardColors(
-                            containerColor = getSystemTextColor(textColor = textColor).copy(
-                                alpha = 0.25f,
-                            ),
-                        ),
-                        border = BorderStroke(
-                            width = 2.dp,
-                            color = getSystemTextColor(textColor = textColor),
+                            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
                         ),
                     ) {
                         GridLayout(


### PR DESCRIPTION
This commit refactors the styling for the placeholder grid shown during drag-and-drop operations on the home screen.

Closes #382 

- The placeholder background color now uses `MaterialTheme.colorScheme.primary` with an alpha of `0.25f`, removing the previous hardcoded border and color logic that was based on `getSystemTextColor`.
- The horizontal padding for the grid pager has been reduced from `50.dp` to `30.dp`.