### PR TITLE
Fix: Add database migration from version 4 to 5

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -16,6 +16,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1288607287">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-812391933">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -8,6 +8,12 @@
       <SelectionState runConfigName="migrate3To4()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="Migration4To5Test">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="Migration3To4Test">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/data/room/src/androidTest/kotlin/com/eblan/launcher/data/room/Migration4To5Test.kt
+++ b/data/room/src/androidTest/kotlin/com/eblan/launcher/data/room/Migration4To5Test.kt
@@ -1,0 +1,274 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.data.room
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.eblan.launcher.data.room.migration.Migration4To5
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class Migration4To5Test {
+    private val testDatabase = "migration-test"
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        EblanDatabase::class.java,
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate4To5() {
+        // Create database at version 4
+        helper.createDatabase(
+            testDatabase,
+            4,
+        ).apply {
+            // EblanApplicationInfoEntity
+            execSQL(
+                """
+                INSERT INTO `EblanApplicationInfoEntity`
+                (packageName, serialNumber, componentName, icon, label) 
+                VALUES ('com.example.app', 1, 'com.example.app/.MainActivity', '/path/icon.png', 'Original App'),
+                ('com.test.app2',   2, 'com.test.app2/.Settings',     NULL,           NULL)
+                """.trimIndent(),
+            )
+
+            // EblanAppWidgetProviderInfoEntity
+            execSQL(
+                """
+                INSERT INTO `EblanAppWidgetProviderInfoEntity` (
+                    componentName, serialNumber, packageName,
+                    targetCellWidth, targetCellHeight, minWidth, minHeight,
+                    resizeMode, minResizeWidth, minResizeHeight,
+                    maxResizeWidth, maxResizeHeight, label
+                ) VALUES 
+                ('com.example.clock', 100, 'com.example.app', 4, 2, 4, 2, 1, 2, 2, 8, 8, 'Clock'),
+                ('com.example.weather', 101, 'com.example.app', 4, 4, 4, 4, 1, 2, 2, 8, 8, NULL),
+                ('com.example.notes', 102, 'com.example.app', 2, 2, 2, 2, 0, 2, 2, 4, 4, 'My Notes')
+                """.trimIndent(),
+            )
+
+            // ApplicationInfoGridItemEntity
+            execSQL(
+                """
+                INSERT INTO `ApplicationInfoGridItemEntity` (id, page, startColumn, startRow, columnSpan, rowSpan,
+                    associate, componentName, packageName, override, serialNumber,
+                    iconSize, textColor, textSize, showLabel, singleLineLabel,
+                    horizontalAlignment, verticalArrangement, label)
+                VALUES 
+                ('item1', 0, 0, 0, 1, 1, 'none', 'com.app/.Main', 'com.app', 0, 100, 48, 
+                 '#FFFFFF', 14, 1, 0, 'center', 'top', 'Browser'),
+                ('item2', 0, 1, 1, 1, 1, 'none', 'com.app/.Notes', 'com.app', 0, 101, 48,
+                 '#000000', 12, 0, 1, 'start', 'bottom', NULL)
+                """.trimIndent(),
+            )
+
+            // WidgetGridItemEntity
+            execSQL(
+                """
+                INSERT INTO `WidgetGridItemEntity` (
+                id, folderId, page, startColumn, startRow, columnSpan, rowSpan,
+                associate, appWidgetId, packageName, componentName, configure,
+                minWidth, minHeight,
+                resizeMode, minResizeWidth, minResizeHeight, maxResizeWidth, maxResizeHeight,
+                targetCellWidth, targetCellHeight,
+                preview, label, icon,
+                override, serialNumber,
+                iconSize, textColor, textSize, showLabel, singleLineLabel,
+                horizontalAlignment, verticalArrangement
+                ) VALUES 
+                ('widget_1', NULL, 0, 0, 0, 4, 2,
+                'none', 101, 'com.example', 'com.example.Clock', NULL,
+                 200, 100,
+                1, 2, 2, 8, 8,           
+                4, 2,
+                NULL, 'Clock', NULL,
+                0, 500,
+                48, '#FFFFFF', 14, 1, 0,
+                'center', 'top'),
+     
+                ('widget_2', NULL, 1, 0, 0, 2, 2,
+                'none', 102, 'com.weather', 'com.weather.Widget', NULL,
+                100, 100,
+                0, 1, 1, 8, 8,          
+                2, 2,
+                NULL, '', NULL,          -- label was NULL → will become '' in v5
+                0, 501,
+                32, '#000000', 12, 0, 1,
+                'start', 'bottom')
+                """.trimIndent(),
+            )
+
+            // FolderGridItemEntity
+            execSQL(
+                """
+                INSERT INTO `FolderGridItemEntity` (
+                    id, page, startColumn, startRow, columnSpan, rowSpan,
+                    associate, label, override, pageCount,
+                    iconSize, textColor, textSize, showLabel, singleLineLabel,
+                    horizontalAlignment, verticalArrangement
+                ) VALUES (
+                    'folder_001', 0, 0, 0, 2, 2,
+                    'folder', 'Work Apps', 0, 3,
+                    64, '#FFFFFF', 16, 1, 0,
+                    'center', 'top'
+                )
+                """.trimIndent(),
+            )
+
+            // ShortcutConfigGridItemEntity
+            execSQL(
+                """
+                INSERT INTO `ShortcutConfigGridItemEntity` (
+                    id, page, startColumn, startRow, columnSpan, rowSpan,
+                    associate, componentName, packageName, activityLabel,
+                    override, serialNumber, iconSize, textColor, textSize,
+                    showLabel, singleLineLabel, horizontalAlignment, verticalArrangement
+                ) VALUES (
+                    'item_001', 0, 1, 2, 1, 1,
+                    'app', 'com.browser/.Main', 'com.browser', 'Browser',
+                    0, 300, 56, '#FFFFFF', 14, 1, 0, 'center', 'bottom'
+                )
+                """.trimIndent(),
+            )
+
+            close()
+        }
+
+        // Run migration and validate version 5
+        val dbV5 = helper.runMigrationsAndValidate(
+            testDatabase,
+            5,
+            true,
+            Migration4To5(),
+        )
+
+        // EblanApplicationInfo
+        dbV5.query(
+            """
+            SELECT componentName, serialNumber, packageName, label, customIcon, customLabel
+            FROM `EblanApplicationInfoEntity`
+            ORDER BY serialNumber
+            """.trimIndent(),
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+
+            // Row 1
+            assertEquals("com.example.app/.MainActivity", cursor.getString(0))
+            assertEquals(1, cursor.getInt(1))
+            assertEquals("com.example.app", cursor.getString(2))
+            assertEquals("Original App", cursor.getString(3))
+            assertNull(cursor.getString(4)) // customIcon
+            assertNull(cursor.getString(5)) // customLabel
+
+            assertTrue(cursor.moveToNext())
+
+            // Row 2 — label was NULL → defaulted to ''
+            assertEquals("com.test.app2/.Settings", cursor.getString(0))
+            assertEquals("", cursor.getString(3)) // label NOT NULL enforced
+            assertNull(cursor.getString(4))
+            assertNull(cursor.getString(5))
+        }
+
+        // EblanAppWidgetProviderInfoEntity
+        dbV5.query("SELECT componentName, label, serialNumber FROM `EblanAppWidgetProviderInfoEntity` ORDER BY serialNumber")
+            .use { cursor ->
+                assertTrue(cursor.moveToFirst())
+
+                // Row 1
+                assertEquals("com.example.clock", cursor.getString(0))
+                assertEquals("Clock", cursor.getString(1))
+
+                cursor.moveToNext()
+                // Row 2 — previously NULL label → now empty string
+                assertEquals("com.example.weather", cursor.getString(0))
+                assertEquals("", cursor.getString(1))
+
+                cursor.moveToNext()
+                // Row 3
+                assertEquals("com.example.notes", cursor.getString(0))
+                assertEquals("My Notes", cursor.getString(1))
+            }
+
+        // ApplicationInfoGridItemEntity
+        dbV5.query("SELECT id, label, customIcon, customLabel FROM `ApplicationInfoGridItemEntity` ORDER BY serialNumber")
+            .use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("item1", c.getString(0))
+                assertEquals("Browser", c.getString(1))
+                assertNull(c.getString(2))
+                assertNull(c.getString(3))
+
+                assertTrue(c.moveToNext())
+
+                assertEquals("item2", c.getString(0))
+                assertEquals("", c.getString(1)) // NULL → ''
+                assertNull(c.getString(2))
+                assertNull(c.getString(3))
+            }
+
+        // WidgetGridItemEntity
+        dbV5.query("SELECT id, label FROM `WidgetGridItemEntity` ORDER BY serialNumber").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("Clock", c.getString(1))
+
+            assertTrue(c.moveToNext())
+
+            assertEquals("", c.getString(1)) // previously NULL → now empty string
+        }
+
+        // FolderGridItemEntity
+        dbV5.query("SELECT label, pageCount, icon, iconSize FROM `FolderGridItemEntity`").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("Work Apps", c.getString(0))
+            assertEquals(3, c.getInt(1))
+            assertNull(c.getString(2)) // icon = NULL (new column)
+            assertEquals(64, c.getInt(3))
+        }
+
+        // ShortcutConfigGridItemEntity
+        dbV5.query("SELECT activityLabel, iconSize, customIcon, customLabel FROM `ShortcutConfigGridItemEntity`")
+            .use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("Browser", c.getString(0))
+                assertEquals(56, c.getInt(1))
+                assertNull(c.getString(2)) // customIcon
+                assertNull(c.getString(3)) // customLabel
+            }
+
+        // New tables should exist and be empty (or ready)
+        dbV5.query("SELECT name FROM sqlite_master WHERE type='table' AND name='EblanIconPackInfoEntity'")
+            .use { cursor ->
+                assertEquals(cursor.count, 1)
+            }
+
+        dbV5.query("SELECT name FROM sqlite_master WHERE type='table' AND name='EblanShortcutConfigEntity'")
+            .use { cursor ->
+                assertEquals(cursor.count, 1)
+            }
+    }
+}

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/migration/Migration3To4.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/migration/Migration3To4.kt
@@ -26,11 +26,11 @@ class Migration3To4 : Migration(3, 4) {
 
         updateEblanAppWidgetProviderInfoEntities(db = db)
 
+        updateEblanShortcutConfigEntities(db = db)
+
         updateApplicationInfoGridItemEntities(db = db)
 
         updateWidgetGridItemEntities(db = db)
-
-        updateEblanShortcutConfigEntities(db = db)
     }
 
     private fun updateEblanApplicationInfoEntities(db: SupportSQLiteDatabase) {
@@ -106,6 +106,57 @@ class Migration3To4 : Migration(3, 4) {
 
         db.execSQL("DROP TABLE `EblanAppWidgetProviderInfoEntity`")
         db.execSQL("ALTER TABLE `EblanAppWidgetProviderInfoEntity_new` RENAME TO `EblanAppWidgetProviderInfoEntity`")
+    }
+
+    private fun updateEblanShortcutConfigEntities(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+                    CREATE TABLE IF NOT EXISTS `EblanShortcutConfigEntity` (
+                        `componentName` TEXT NOT NULL,
+                        `packageName` TEXT NOT NULL,
+                        `serialNumber` INTEGER NOT NULL,
+                        `activityIcon` TEXT,
+                        `activityLabel` TEXT,
+                        `applicationIcon` TEXT,
+                        `applicationLabel` TEXT,
+                        PRIMARY KEY(`componentName`, `serialNumber`)
+                    )
+            """.trimIndent(),
+        )
+
+        db.execSQL(
+            """
+                    CREATE TABLE IF NOT EXISTS `ShortcutConfigGridItemEntity` (
+                        `id` TEXT NOT NULL,
+                        `folderId` TEXT,
+                        `page` INTEGER NOT NULL,
+                        `startColumn` INTEGER NOT NULL,
+                        `startRow` INTEGER NOT NULL,
+                        `columnSpan` INTEGER NOT NULL,
+                        `rowSpan` INTEGER NOT NULL,
+                        `associate` TEXT NOT NULL,
+                        `componentName` TEXT NOT NULL,
+                        `packageName` TEXT NOT NULL,
+                        `activityIcon` TEXT,
+                        `activityLabel` TEXT,
+                        `applicationIcon` TEXT,
+                        `applicationLabel` TEXT,
+                        `override` INTEGER NOT NULL,
+                        `serialNumber` INTEGER NOT NULL,
+                        `shortcutIntentName` TEXT,
+                        `shortcutIntentIcon` TEXT,
+                        `shortcutIntentUri` TEXT,
+                        `iconSize` INTEGER NOT NULL,
+                        `textColor` TEXT NOT NULL,
+                        `textSize` INTEGER NOT NULL,
+                        `showLabel` INTEGER NOT NULL,
+                        `singleLineLabel` INTEGER NOT NULL,
+                        `horizontalAlignment` TEXT NOT NULL,
+                        `verticalArrangement` TEXT NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+            """.trimIndent(),
+        )
     }
 
     private fun updateApplicationInfoGridItemEntities(db: SupportSQLiteDatabase) {
@@ -214,56 +265,5 @@ class Migration3To4 : Migration(3, 4) {
 
         db.execSQL("DROP TABLE `WidgetGridItemEntity`")
         db.execSQL("ALTER TABLE `WidgetGridItemEntity_new` RENAME TO `WidgetGridItemEntity`")
-    }
-
-    private fun updateEblanShortcutConfigEntities(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            """
-                    CREATE TABLE IF NOT EXISTS `EblanShortcutConfigEntity` (
-                        `componentName` TEXT NOT NULL,
-                        `packageName` TEXT NOT NULL,
-                        `serialNumber` INTEGER NOT NULL,
-                        `activityIcon` TEXT,
-                        `activityLabel` TEXT,
-                        `applicationIcon` TEXT,
-                        `applicationLabel` TEXT,
-                        PRIMARY KEY(`componentName`, `serialNumber`)
-                    )
-            """.trimIndent(),
-        )
-
-        db.execSQL(
-            """
-                    CREATE TABLE IF NOT EXISTS `ShortcutConfigGridItemEntity` (
-                        `id` TEXT NOT NULL,
-                        `folderId` TEXT,
-                        `page` INTEGER NOT NULL,
-                        `startColumn` INTEGER NOT NULL,
-                        `startRow` INTEGER NOT NULL,
-                        `columnSpan` INTEGER NOT NULL,
-                        `rowSpan` INTEGER NOT NULL,
-                        `associate` TEXT NOT NULL,
-                        `componentName` TEXT NOT NULL,
-                        `packageName` TEXT NOT NULL,
-                        `activityIcon` TEXT,
-                        `activityLabel` TEXT,
-                        `applicationIcon` TEXT,
-                        `applicationLabel` TEXT,
-                        `override` INTEGER NOT NULL,
-                        `serialNumber` INTEGER NOT NULL,
-                        `shortcutIntentName` TEXT,
-                        `shortcutIntentIcon` TEXT,
-                        `shortcutIntentUri` TEXT,
-                        `iconSize` INTEGER NOT NULL,
-                        `textColor` TEXT NOT NULL,
-                        `textSize` INTEGER NOT NULL,
-                        `showLabel` INTEGER NOT NULL,
-                        `singleLineLabel` INTEGER NOT NULL,
-                        `horizontalAlignment` TEXT NOT NULL,
-                        `verticalArrangement` TEXT NOT NULL,
-                        PRIMARY KEY(`id`)
-                    )
-            """.trimIndent(),
-        )
     }
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/migration/Migration4To5.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/migration/Migration4To5.kt
@@ -1,0 +1,356 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.data.room.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration4To5 : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        updateEblanApplicationInfoEntities(db = db)
+
+        updateEblanAppWidgetProviderInfoEntities(db = db)
+
+        updateApplicationInfoGridItemEntities(db = db)
+
+        updateWidgetGridItemEntities(db = db)
+
+        updateShortcutInfoGridItemEntities(db = db)
+
+        updateFolderGridItemEntities(db = db)
+
+        updateShortcutConfigGridItemEntities(db = db)
+    }
+
+    private fun updateEblanApplicationInfoEntities(db: SupportSQLiteDatabase) {
+        // Step 1: Create the new table with the exact version 5 schema
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `EblanApplicationInfoEntity_new` (
+                componentName TEXT NOT NULL,
+                serialNumber INTEGER NOT NULL,
+                packageName TEXT NOT NULL,
+                icon TEXT,
+                label TEXT NOT NULL DEFAULT '',
+                customIcon TEXT,
+                customLabel TEXT,
+                PRIMARY KEY(componentName, serialNumber)
+            )
+            """.trimIndent(),
+        )
+
+        // Step 2: Copy all data from old table to new table
+        // We set label = COALESCE(label, '') to satisfy NOT NULL constraint
+        db.execSQL(
+            """
+            INSERT INTO `EblanApplicationInfoEntity_new` (
+                componentName, serialNumber, packageName,
+                icon, label, customIcon, customLabel
+            )
+            SELECT 
+                componentName, 
+                serialNumber, 
+                packageName,
+                icon, 
+                COALESCE(label, '') AS label,
+                NULL AS customIcon,
+                NULL AS customLabel
+            FROM EblanApplicationInfoEntity
+            """.trimIndent(),
+        )
+
+        // Step 3: Drop the old table
+        db.execSQL("DROP TABLE `EblanApplicationInfoEntity`")
+
+        // Step 4: Rename new table to final name
+        db.execSQL("ALTER TABLE `EblanApplicationInfoEntity_new` RENAME TO `EblanApplicationInfoEntity`")
+    }
+
+    private fun updateEblanAppWidgetProviderInfoEntities(db: SupportSQLiteDatabase) {
+// Step 1: Add the label column again as NOT NULL with default empty string
+        // SQLite does not allow modifying a column directly to NOT NULL if it contains NULLs,
+        // so we use the standard safe pattern: rename → create new → copy → drop old → rename back
+
+        db.execSQL("ALTER TABLE `EblanAppWidgetProviderInfoEntity` RENAME TO `EblanAppWidgetProviderInfoEntity_old`")
+
+        // Step 2: Create the new table matching exactly the version 5 schema
+        db.execSQL(
+            """
+            CREATE TABLE `EblanAppWidgetProviderInfoEntity` (
+                componentName TEXT NOT NULL,
+                serialNumber INTEGER NOT NULL,
+                configure TEXT,
+                packageName TEXT NOT NULL,
+                targetCellWidth INTEGER NOT NULL,
+                targetCellHeight INTEGER NOT NULL,
+                minWidth INTEGER NOT NULL,
+                minHeight INTEGER NOT NULL,
+                resizeMode INTEGER NOT NULL,
+                minResizeWidth INTEGER NOT NULL,
+                minResizeHeight INTEGER NOT NULL,
+                maxResizeWidth INTEGER NOT NULL,
+                maxResizeHeight INTEGER NOT NULL,
+                preview TEXT,
+                label TEXT NOT NULL DEFAULT '',
+                icon TEXT,
+                PRIMARY KEY(componentName)
+            )
+            """.trimIndent(),
+        )
+
+        // Step 3: Copy all data — NULL labels become empty string
+        db.execSQL(
+            """
+            INSERT INTO `EblanAppWidgetProviderInfoEntity` (
+                componentName, serialNumber, configure, packageName,
+                targetCellWidth, targetCellHeight, minWidth, minHeight,
+                resizeMode, minResizeWidth, minResizeHeight,
+                maxResizeWidth, maxResizeHeight, preview, label, icon
+            )
+            SELECT 
+                componentName, serialNumber, configure, packageName,
+                targetCellWidth, targetCellHeight, minWidth, minHeight,
+                resizeMode, minResizeWidth, minResizeHeight,
+                maxResizeWidth, maxResizeHeight, preview,
+                COALESCE(label, '') AS label,
+                icon
+            FROM `EblanAppWidgetProviderInfoEntity_old`
+            """.trimIndent(),
+        )
+
+        // Step 4: Drop the old table
+        db.execSQL("DROP TABLE `EblanAppWidgetProviderInfoEntity_old`")
+    }
+
+    private fun updateApplicationInfoGridItemEntities(db: SupportSQLiteDatabase) {
+// Step 1: Create new table matching EXACTLY the version 5 schema
+        db.execSQL(
+            """
+            CREATE TABLE `ApplicationInfoGridItemEntity_new` (
+                id TEXT NOT NULL,
+                folderId TEXT,
+                page INTEGER NOT NULL,
+                startColumn INTEGER NOT NULL,
+                startRow INTEGER NOT NULL,
+                columnSpan INTEGER NOT NULL,
+                rowSpan INTEGER NOT NULL,
+                associate TEXT NOT NULL,
+                componentName TEXT NOT NULL,
+                packageName TEXT NOT NULL,
+                icon TEXT,
+                label TEXT NOT NULL DEFAULT '',
+                override INTEGER NOT NULL,
+                serialNumber INTEGER NOT NULL,
+                customIcon TEXT,
+                customLabel TEXT,
+                iconSize INTEGER NOT NULL,
+                textColor TEXT NOT NULL,
+                textSize INTEGER NOT NULL,
+                showLabel INTEGER NOT NULL,
+                singleLineLabel INTEGER NOT NULL,
+                horizontalAlignment TEXT NOT NULL,
+                verticalArrangement TEXT NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """.trimIndent(),
+        )
+
+        // Step 2: Copy all data — NULL labels become empty string, new columns = NULL
+        db.execSQL(
+            """
+            INSERT INTO `ApplicationInfoGridItemEntity_new` (
+                id, folderId, page, startColumn, startRow, columnSpan, rowSpan,
+                associate, componentName, packageName, icon,
+                label, override, serialNumber,
+                customIcon, customLabel,
+                iconSize, textColor, textSize, showLabel, singleLineLabel,
+                horizontalAlignment, verticalArrangement
+            )
+            SELECT 
+                id, folderId, page, startColumn, startRow, columnSpan, rowSpan,
+                associate, componentName, packageName, icon,
+                COALESCE(label, '') AS label,
+                override, serialNumber,
+                NULL AS customIcon,
+                NULL AS customLabel,
+                iconSize, textColor, textSize, showLabel, singleLineLabel,
+                horizontalAlignment, verticalArrangement
+            FROM `ApplicationInfoGridItemEntity`
+            """.trimIndent(),
+        )
+
+        // Step 3: Drop old table and rename new one
+        db.execSQL("DROP TABLE `ApplicationInfoGridItemEntity`")
+        db.execSQL("ALTER TABLE `ApplicationInfoGridItemEntity_new` RENAME TO `ApplicationInfoGridItemEntity`")
+    }
+
+    private fun updateWidgetGridItemEntities(db: SupportSQLiteDatabase) {
+// Step 1: Create the new table with the exact version 5 schema
+        db.execSQL(
+            """
+            CREATE TABLE `WidgetGridItemEntity_new` (
+                id TEXT NOT NULL,
+                folderId TEXT,
+                page INTEGER NOT NULL,
+                startColumn INTEGER NOT NULL,
+                startRow INTEGER NOT NULL,
+                columnSpan INTEGER NOT NULL,
+                rowSpan INTEGER NOT NULL,
+                associate TEXT NOT NULL,
+                appWidgetId INTEGER NOT NULL,
+                packageName TEXT NOT NULL,
+                componentName TEXT NOT NULL,
+                configure TEXT,
+                minWidth INTEGER NOT NULL,
+                minHeight INTEGER NOT NULL,
+                resizeMode INTEGER NOT NULL,
+                minResizeWidth INTEGER NOT NULL,
+                minResizeHeight INTEGER NOT NULL,
+                maxResizeWidth INTEGER NOT NULL,
+                maxResizeHeight INTEGER NOT NULL,
+                targetCellHeight INTEGER NOT NULL,
+                targetCellWidth INTEGER NOT NULL,
+                preview TEXT,
+                label TEXT NOT NULL DEFAULT '',
+                icon TEXT,
+                override INTEGER NOT NULL,
+                serialNumber INTEGER NOT NULL,
+                iconSize INTEGER NOT NULL,
+                textColor TEXT NOT NULL,
+                textSize INTEGER NOT NULL,
+                showLabel INTEGER NOT NULL,
+                singleLineLabel INTEGER NOT NULL,
+                horizontalAlignment TEXT NOT NULL,
+                verticalArrangement TEXT NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """.trimIndent(),
+        )
+
+        // Step 2: Copy all existing data – convert any NULL label → empty string
+        db.execSQL(
+            """
+            INSERT INTO `WidgetGridItemEntity_new`
+            SELECT 
+                id,
+                folderId,
+                page,
+                startColumn,
+                startRow,
+                columnSpan,
+                rowSpan,
+                associate,
+                appWidgetId,
+                packageName,
+                componentName,
+                configure,
+                minWidth,
+                minHeight,
+                resizeMode,
+                minResizeWidth,
+                minResizeHeight,
+                maxResizeWidth,
+                maxResizeHeight,
+                targetCellHeight,
+                targetCellWidth,
+                preview,
+                COALESCE(label, '') AS label,
+                icon,
+                override,
+                serialNumber,
+                iconSize,
+                textColor,
+                textSize,
+                showLabel,
+                singleLineLabel,
+                horizontalAlignment,
+                verticalArrangement
+            FROM `WidgetGridItemEntity`
+            """.trimIndent(),
+        )
+
+        // Step 3: Replace old table
+        db.execSQL("DROP TABLE `WidgetGridItemEntity`")
+        db.execSQL("ALTER TABLE `WidgetGridItemEntity_new` RENAME TO `WidgetGridItemEntity`")
+    }
+
+    private fun updateShortcutInfoGridItemEntities(db: SupportSQLiteDatabase) {
+        // Add the two new columns — both nullable, so safe to add directly
+        db.execSQL("ALTER TABLE `ShortcutInfoGridItemEntity` ADD COLUMN `customIcon` TEXT")
+        db.execSQL("ALTER TABLE `ShortcutInfoGridItemEntity` ADD COLUMN `customShortLabel` TEXT")
+    }
+
+    private fun updateFolderGridItemEntities(db: SupportSQLiteDatabase) {
+        // 1. Create new table with exact version 5 schema
+        db.execSQL(
+            """
+            CREATE TABLE `FolderGridItemEntity_new` (
+                id TEXT NOT NULL,
+                folderId TEXT,
+                page INTEGER NOT NULL,
+                startColumn INTEGER NOT NULL,
+                startRow INTEGER NOT NULL,
+                columnSpan INTEGER NOT NULL,
+                rowSpan INTEGER NOT NULL,
+                associate TEXT NOT NULL,
+                label TEXT NOT NULL,
+                override INTEGER NOT NULL,
+                pageCount INTEGER NOT NULL,
+                icon TEXT,
+                iconSize INTEGER NOT NULL,
+                textColor TEXT NOT NULL,
+                textSize INTEGER NOT NULL,
+                showLabel INTEGER NOT NULL,
+                singleLineLabel INTEGER NOT NULL,
+                horizontalAlignment TEXT NOT NULL,
+                verticalArrangement TEXT NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """.trimIndent(),
+        )
+
+        // 2. Copy all data — new `icon` column will be NULL
+        db.execSQL(
+            """
+            INSERT INTO `FolderGridItemEntity_new` (
+                id, folderId, page, startColumn, startRow, columnSpan, rowSpan,
+                associate, label, override, pageCount,
+                icon,
+                iconSize, textColor, textSize, showLabel, singleLineLabel,
+                horizontalAlignment, verticalArrangement
+            )
+            SELECT 
+                id, folderId, page, startColumn, startRow, columnSpan, rowSpan,
+                associate, label, override, pageCount,
+                NULL AS icon,
+                iconSize, textColor, textSize, showLabel, singleLineLabel,
+                horizontalAlignment, verticalArrangement
+            FROM `FolderGridItemEntity`
+            """.trimIndent(),
+        )
+
+        // 3. Replace old table
+        db.execSQL("DROP TABLE `FolderGridItemEntity`")
+        db.execSQL("ALTER TABLE `FolderGridItemEntity_new` RENAME TO `FolderGridItemEntity`")
+    }
+
+    private fun updateShortcutConfigGridItemEntities(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `ShortcutConfigGridItemEntity` ADD COLUMN `customIcon` TEXT")
+        db.execSQL("ALTER TABLE `ShortcutConfigGridItemEntity` ADD COLUMN `customLabel` TEXT")
+    }
+}


### PR DESCRIPTION
This commit introduces the database migration from version 4 to 5 and adds a corresponding migration test. The primary changes involve making `label` fields non-nullable and adding new columns to support custom icons and labels across various entities.

This migration ensures data integrity by enforcing that all labels have a value and lays the groundwork for upcoming customization features.

### Core Changes:

-   **Database Migration (v4 to v5)**:
    -   **`EblanApplicationInfoEntity`**:
        -   The `label` column is now `TEXT NOT NULL` with a default value of `''`.
        -   New nullable columns `customIcon` and `customLabel` have been added.
    -   **`EblanAppWidgetProviderInfoEntity`**:
        -   The `label` column is now `TEXT NOT NULL` with a default of `''`.
    -   **`ApplicationInfoGridItemEntity`**:
        -   The `label` column is now `TEXT NOT NULL`.
        -   New nullable columns `customIcon` and `customLabel` have been added.
    -   **`WidgetGridItemEntity`**:
        -   The `label` column is now `TEXT NOT NULL`.
    -   **`FolderGridItemEntity`**:
        -   A new nullable `icon` column has been added to support custom folder icons.
    -   **`ShortcutInfoGridItemEntity`**:
        -   New nullable columns `customIcon` and `customShortLabel` have been added.
    -   **`ShortcutConfigGridItemEntity`**:
        -   New nullable columns `customIcon` and `customLabel` have been added.

-   **Migration Test (`Migration4To5Test.kt`)**:
    -   A new comprehensive test case has been added to validate the schema changes and data integrity after migrating from version 4 to 5.
    -   The test verifies that `NULL` labels are correctly migrated to empty strings (`''`) and that all new columns (`customIcon`, `customLabel`, etc.) are correctly added with `NULL` values.

-   **Migration Refactor (`Migration3To4.kt`)**:
    -   Minor code reordering was done to improve readability.