### PR TITLE
Refactor: Use constructor for empty Bundle

### DIFF
--- a/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetHostWrapper.kt
+++ b/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetHostWrapper.kt
@@ -54,14 +54,14 @@ internal class DefaultAppWidgetHostWrapper @Inject constructor(@param:Applicatio
         return appWidgetHost.createView(context, appWidgetId, appWidgetProviderInfo).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 updateAppWidgetSize(
-                    Bundle.EMPTY,
+                    Bundle(),
                     listOf(
                         SizeF(minWidth.toFloat(), minHeight.toFloat()),
                     ),
                 )
             } else {
                 updateAppWidgetSize(
-                    Bundle.EMPTY,
+                    Bundle(),
                     minWidth,
                     minHeight,
                     minWidth,


### PR DESCRIPTION
This commit replaces the use of `Bundle.EMPTY` with the `Bundle()` constructor.
Fixes #395 

Using `Bundle()` is the modern and recommended approach, as `Bundle.EMPTY` is a static, read-only instance that can lead to subtle issues if unintentionally modified elsewhere. This change improves code clarity and safety.