### PR TITLE
Fix: Dismiss screens when returning to home

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -299,6 +299,8 @@ private fun SharedTransitionScope.Success(
 
     LaunchedEffect(key1 = isPressHome) {
         if (isPressHome) {
+            focusManager.clearFocus()
+
             showPopupApplicationMenu = false
 
             onDismiss()
@@ -328,6 +330,7 @@ private fun SharedTransitionScope.Success(
             appDrawerSettings = appDrawerSettings,
             iconPackFilePaths = iconPackFilePaths,
             paddingValues = paddingValues,
+            isPressHome = isPressHome,
             onUpdateGridItemOffset = { intOffset, intSize ->
                 onUpdateGridItemOffset(intOffset, intSize)
 
@@ -494,6 +497,7 @@ private fun SharedTransitionScope.EblanApplicationInfoDockSearchBar(
     eblanApplicationInfosByLabel: List<EblanApplicationInfo>,
     paddingValues: PaddingValues,
     iconPackFilePaths: Map<String, String>,
+    isPressHome: Boolean,
     onUpdateGridItemOffset: (
         intOffset: IntOffset,
         intSize: IntSize,
@@ -510,6 +514,12 @@ private fun SharedTransitionScope.EblanApplicationInfoDockSearchBar(
     var query by remember { mutableStateOf("") }
 
     var expanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(key1 = isPressHome) {
+        if (isPressHome) {
+            expanded = false
+        }
+    }
 
     DockedSearchBar(
         modifier = modifier

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
@@ -17,7 +17,10 @@
  */
 package com.eblan.launcher.feature.home.screen.editpage
 
+import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -43,17 +46,20 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.core.util.Consumer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.HomeSettings
 import com.eblan.launcher.domain.model.PageItem
@@ -63,6 +69,8 @@ import com.eblan.launcher.feature.home.component.grid.GridLayout
 import com.eblan.launcher.feature.home.model.Screen
 import com.eblan.launcher.feature.home.util.getGridItemTextColor
 import com.eblan.launcher.feature.home.util.getSystemTextColor
+import com.eblan.launcher.feature.home.util.handleActionMainIntent
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -116,6 +124,27 @@ internal fun SharedTransitionScope.EditPageScreen(
     val isAtTop by remember(key1 = lazyGridState) {
         derivedStateOf {
             lazyGridState.firstVisibleItemIndex == 0 && lazyGridState.firstVisibleItemScrollOffset == 0
+        }
+    }
+
+    val activity = LocalActivity.current as ComponentActivity
+
+    val scope = rememberCoroutineScope()
+
+    DisposableEffect(key1 = activity) {
+        val listener = Consumer<Intent> { intent ->
+            scope.launch {
+                handleActionMainIntent(
+                    intent = intent,
+                    onUpdateScreen = onUpdateScreen,
+                )
+            }
+        }
+
+        activity.addOnNewIntentListener(listener)
+
+        onDispose {
+            activity.removeOnNewIntentListener(listener)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -266,6 +266,8 @@ private fun SharedTransitionScope.Success(
     onDragEnd: (Float) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
+
     val horizontalPagerState = rememberPagerState(
         pageCount = {
             eblanShortcutConfigs.keys.size
@@ -286,7 +288,11 @@ private fun SharedTransitionScope.Success(
             onQueryChange = onGetEblanShortcutConfigsByLabel,
             eblanShortcutConfigsByLabel = eblanShortcutConfigsByLabel,
             drag = drag,
-            onUpdateGridItemOffset = onUpdateGridItemOffset,
+            onUpdateGridItemOffset = { intOffset, intSize ->
+                onUpdateGridItemOffset(intOffset, intSize)
+
+                focusManager.clearFocus()
+            },
             onLongPressGridItem = onLongPressGridItem,
             currentPage = currentPage,
             gridItemSettings = gridItemSettings,
@@ -363,8 +369,6 @@ private fun SharedTransitionScope.EblanShortcutConfigDockSearchBar(
     onDraggingGridItem: () -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
-    val focusManager = LocalFocusManager.current
-
     var query by remember { mutableStateOf("") }
 
     var expanded by remember { mutableStateOf(false) }
@@ -399,14 +403,7 @@ private fun SharedTransitionScope.EblanShortcutConfigDockSearchBar(
                     eblanApplicationInfoGroup = eblanApplicationInfoGroup,
                     eblanShortcutConfigs = eblanShortcutConfigsByLabel,
                     drag = drag,
-                    onUpdateGridItemOffset = { intOffset, intSize ->
-                        focusManager.clearFocus()
-
-                        onUpdateGridItemOffset(
-                            intOffset,
-                            intSize,
-                        )
-                    },
+                    onUpdateGridItemOffset = onUpdateGridItemOffset,
                     onLongPressGridItem = onLongPressGridItem,
                     currentPage = currentPage,
                     gridItemSettings = gridItemSettings,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -254,6 +254,8 @@ private fun SharedTransitionScope.Success(
     onDragEnd: (Float) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
+
     val scope = rememberCoroutineScope()
 
     val lazyListState = rememberLazyListState()
@@ -305,7 +307,11 @@ private fun SharedTransitionScope.Success(
             onQueryChange = onGetEblanAppWidgetProviderInfosByLabel,
             eblanAppWidgetProviderInfosByLabel = eblanAppWidgetProviderInfosByLabel,
             drag = drag,
-            onUpdateGridItemOffset = onUpdateGridItemOffset,
+            onUpdateGridItemOffset = { intOffset, intSize ->
+                onUpdateGridItemOffset(intOffset, intSize)
+
+                focusManager.clearFocus()
+            },
             onLongPressGridItem = onLongPressGridItem,
             currentPage = currentPage,
             gridItemSettings = gridItemSettings,
@@ -359,8 +365,6 @@ private fun SharedTransitionScope.EblanAppWidgetProviderInfoDockSearchBar(
     onDraggingGridItem: () -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
-    val focusManager = LocalFocusManager.current
-
     var query by remember { mutableStateOf("") }
 
     var expanded by remember { mutableStateOf(false) }
@@ -394,14 +398,7 @@ private fun SharedTransitionScope.EblanAppWidgetProviderInfoDockSearchBar(
                     eblanApplicationInfoGroup = eblanApplicationInfo,
                     eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfosByLabel,
                     drag = drag,
-                    onUpdateGridItemOffset = { intOffset, intSize ->
-                        focusManager.clearFocus()
-
-                        onUpdateGridItemOffset(
-                            intOffset,
-                            intSize,
-                        )
-                    },
+                    onUpdateGridItemOffset = onUpdateGridItemOffset,
                     onLongPressGridItem = onLongPressGridItem,
                     currentPage = currentPage,
                     gridItemSettings = gridItemSettings,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
@@ -1,0 +1,36 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.home.util
+
+import android.content.Intent
+import com.eblan.launcher.feature.home.model.Screen
+
+internal fun handleActionMainIntent(
+    intent: Intent,
+    onUpdateScreen: (Screen) -> Unit,
+) {
+    if (intent.action != Intent.ACTION_MAIN && !intent.hasCategory(Intent.CATEGORY_HOME)) {
+        return
+    }
+
+    if ((intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
+        return
+    }
+
+    onUpdateScreen(Screen.Pager)
+}


### PR DESCRIPTION
Fixes #431 
Fixes #432 

This commit fixes an issue where the folder, edit page, widget, and shortcut picker screens would remain open in the background when the user navigated back to the home screen using the home button or a similar `ACTION_MAIN` intent. It also clears focus from search bars in these screens when this action occurs.

Previously, these screens did not handle the `ACTION_MAIN` intent, causing them to reappear unexpectedly when the app was reopened.

This is resolved by introducing a new utility function, `handleActionMainIntent`, which encapsulates the logic for returning to the main pager screen. This function is now used in `FolderScreen`, and `EditPageScreen` via a `DisposableEffect` that listens for new intents. When an `ACTION_MAIN` intent is detected, these screens now correctly navigate back to the pager.

### Core Changes:

*   **New Utility Function (`HomeUtil.kt`):**
    *   Created `handleActionMainIntent` to centralize the logic for dismissing a screen when an `ACTION_MAIN` intent is received. It calls `onUpdateScreen(Screen.Pager)`.

*   **Intent Handling in Screens:**
    *   **`FolderScreen.kt` & `EditPageScreen.kt`:** Added a `DisposableEffect` to register an `OnNewIntentListener`. This listener uses the new `handleActionMainIntent` utility to dismiss the screen when the user navigates home.

*   **Focus Management:**
    *   **`WidgetScreen.kt` & `ShortcutConfigScreen.kt`:** The `FocusManager` now clears focus from the search bar when an item is being dragged. This prevents the keyboard from remaining open.
    *   **`ApplicationScreen.kt`:** The search bar is now correctly dismissed and focus is cleared when the home button is pressed.