### PR TITLE
Feat: Add experimental setting to lock grid item movement

### DIFF
--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
@@ -90,6 +90,7 @@ class UserDataSerializer @Inject constructor() : Serializer<UserDataProto> {
     private val defaultExperimentalSettings = ExperimentalSettingsProto.newBuilder().apply {
         syncData = true
         firstLaunch = true
+        lockMovement = false
     }.build()
 
     override val defaultValue: UserDataProto = UserDataProto.newBuilder().apply {

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -292,6 +292,7 @@ internal fun ExperimentalSettings.toExperimentalSettingsProto(): ExperimentalSet
     return ExperimentalSettingsProto.newBuilder()
         .setSyncData(syncData)
         .setFirstLaunch(firstLaunch)
+        .setLockMovement(lockMovement)
         .build()
 }
 
@@ -299,5 +300,6 @@ internal fun ExperimentalSettingsProto.toExperimentalSettings(): ExperimentalSet
     return ExperimentalSettings(
         syncData = syncData,
         firstLaunch = firstLaunch,
+        lockMovement = lockMovement,
     )
 }

--- a/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/experimental/experimental_settings.proto
+++ b/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/experimental/experimental_settings.proto
@@ -6,4 +6,5 @@ option java_multiple_files = true;
 message ExperimentalSettingsProto {
   bool syncData = 1;
   bool firstLaunch = 2;
+  bool lockMovement = 3;
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ExperimentalSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ExperimentalSettings.kt
@@ -20,4 +20,5 @@ package com.eblan.launcher.domain.model
 data class ExperimentalSettings(
     val syncData: Boolean,
     val firstLaunch: Boolean,
+    val lockMovement: Boolean,
 )

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
@@ -47,6 +47,7 @@ class MoveGridItemUseCase @Inject constructor(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ): MoveGridItemResult {
         return withContext(defaultDispatcher) {
             val gridItems = gridCacheRepository.gridItemsCache.first().filter { gridItem ->
@@ -95,6 +96,7 @@ class MoveGridItemUseCase @Inject constructor(
                     columns = columns,
                     rows = rows,
                     gridWidth = gridWidth,
+                    lockMovement = lockMovement,
                 )
             }
 
@@ -105,7 +107,7 @@ class MoveGridItemUseCase @Inject constructor(
                 )
             }
 
-            if (gridItemBySpan != null) {
+            if (lockMovement && gridItemBySpan != null) {
                 return@withContext handleConflictsOfGridItemSpan(
                     movingGridItem = movingGridItem,
                     gridItemBySpan = gridItemBySpan,
@@ -133,6 +135,7 @@ class MoveGridItemUseCase @Inject constructor(
         columns: Int,
         rows: Int,
         gridWidth: Int,
+        lockMovement: Boolean,
     ): MoveGridItemResult {
         val resolveDirection = getResolveDirectionByX(
             gridItem = gridItemByCoordinates,
@@ -151,7 +154,7 @@ class MoveGridItemUseCase @Inject constructor(
                     rows = rows,
                 )
 
-                if (resolvedConflicts) {
+                if (resolvedConflicts && !lockMovement) {
                     gridCacheRepository.upsertGridItems(gridItems = gridItems)
                 }
 
@@ -163,7 +166,9 @@ class MoveGridItemUseCase @Inject constructor(
             }
 
             ResolveDirection.Center -> {
-                gridCacheRepository.upsertGridItems(gridItems = gridItems)
+                if (!lockMovement) {
+                    gridCacheRepository.upsertGridItems(gridItems = gridItems)
+                }
 
                 MoveGridItemResult(
                     isSuccess = true,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
@@ -39,6 +39,7 @@ class ResizeGridItemUseCase @Inject constructor(
         resizingGridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) {
         withContext(defaultDispatcher) {
             val gridItems = gridCacheRepository.gridItemsCache.first().filter { gridItem ->
@@ -86,7 +87,7 @@ class ResizeGridItemUseCase @Inject constructor(
                     rows = rows,
                 )
 
-                if (resolvedConflicts) {
+                if (resolvedConflicts && !lockMovement) {
                     gridCacheRepository.upsertGridItems(gridItems = gridItems)
                 }
             } else {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -230,6 +230,7 @@ internal fun HomeScreen(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onMoveFolderGridItem: (
         movingGridItem: GridItem,
@@ -244,6 +245,7 @@ internal fun HomeScreen(
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onShowGridCache: (
         gridItems: List<GridItem>,
@@ -572,6 +574,7 @@ private fun SharedTransitionScope.Success(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onMoveFolderGridItem: (
         movingGridItem: GridItem,
@@ -586,6 +589,7 @@ private fun SharedTransitionScope.Success(
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onShowGridCache: (
         gridItems: List<GridItem>,
@@ -831,6 +835,7 @@ private fun SharedTransitionScope.Success(
                     statusBarNotifications = statusBarNotifications,
                     hasShortcutHostPermission = homeData.hasShortcutHostPermission,
                     iconPackFilePaths = iconPackFilePaths,
+                    lockMovement = homeData.userData.experimentalSettings.lockMovement,
                     onMoveGridItem = onMoveGridItem,
                     onDragEndAfterMove = onResetGridCacheAfterMove,
                     onDragCancelAfterMove = onCancelGridCache,
@@ -857,6 +862,7 @@ private fun SharedTransitionScope.Success(
                     statusBarNotifications = statusBarNotifications,
                     hasShortcutHostPermission = homeData.hasShortcutHostPermission,
                     iconPackFilePaths = iconPackFilePaths,
+                    lockMovement = homeData.userData.experimentalSettings.lockMovement,
                     onResizeGridItem = onResizeGridItem,
                     onResizeEnd = onResetGridCacheAfterResize,
                     onResizeCancel = onCancelGridCache,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -220,6 +220,7 @@ internal class HomeViewModel @Inject constructor(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ) {
         moveGridItemJob?.cancel()
 
@@ -233,6 +234,7 @@ internal class HomeViewModel @Inject constructor(
                     rows = rows,
                     gridWidth = gridWidth,
                     gridHeight = gridHeight,
+                    lockMovement = lockMovement,
                 )
             }
         }
@@ -242,6 +244,7 @@ internal class HomeViewModel @Inject constructor(
         resizingGridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) {
         moveGridItemJob?.cancel()
 
@@ -250,6 +253,7 @@ internal class HomeViewModel @Inject constructor(
                 resizingGridItem = resizingGridItem,
                 columns = columns,
                 rows = rows,
+                lockMovement = lockMovement,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -71,6 +71,7 @@ internal suspend fun handleDragGridItem(
     isScrollInProgress: Boolean,
     gridItemSource: GridItemSource,
     paddingValues: PaddingValues,
+    lockMovement: Boolean,
     onUpdatePageDirection: (PageDirection) -> Unit,
     onMoveGridItem: (
         movingGridItem: GridItem,
@@ -80,6 +81,7 @@ internal suspend fun handleDragGridItem(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ) -> Unit,
 ) {
     if (drag == Drag.None ||
@@ -179,6 +181,7 @@ internal suspend fun handleDragGridItem(
                 dockRows,
                 gridWidth,
                 dockHeightPx,
+                lockMovement,
             )
         }
     } else {
@@ -220,6 +223,7 @@ internal suspend fun handleDragGridItem(
                 rows,
                 gridWidth,
                 gridHeightWithPadding,
+                lockMovement,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -94,6 +94,7 @@ internal fun SharedTransitionScope.DragScreen(
     statusBarNotifications: Map<String, Int>,
     hasShortcutHostPermission: Boolean,
     iconPackFilePaths: Map<String, String>,
+    lockMovement: Boolean,
     onMoveGridItem: (
         movingGridItem: GridItem,
         x: Int,
@@ -102,6 +103,7 @@ internal fun SharedTransitionScope.DragScreen(
         rows: Int,
         gridWidth: Int,
         gridHeight: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onDragEndAfterMove: (MoveGridItemResult) -> Unit,
     onDragCancelAfterMove: () -> Unit,
@@ -242,6 +244,7 @@ internal fun SharedTransitionScope.DragScreen(
             isScrollInProgress = gridHorizontalPagerState.isScrollInProgress,
             gridItemSource = gridItemSource,
             paddingValues = paddingValues,
+            lockMovement = lockMovement,
             onUpdatePageDirection = { newPageDirection ->
                 pageDirection = newPageDirection
             },

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
@@ -62,10 +62,12 @@ internal fun GridItemResizeOverlay(
     width: Int,
     height: Int,
     color: Color,
+    lockMovement: Boolean,
     onResizeGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
 ) {
@@ -258,6 +260,7 @@ internal fun GridItemResizeOverlay(
                 resizingGridItem,
                 columns,
                 rows,
+                lockMovement,
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/ResizeScreen.kt
@@ -61,10 +61,12 @@ internal fun SharedTransitionScope.ResizeScreen(
     statusBarNotifications: Map<String, Int>,
     hasShortcutHostPermission: Boolean,
     iconPackFilePaths: Map<String, String>,
+    lockMovement: Boolean,
     onResizeGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
     onResizeCancel: () -> Unit,
@@ -228,6 +230,7 @@ internal fun SharedTransitionScope.ResizeScreen(
                 width = width,
                 height = height,
                 textColor = textColor,
+                lockMovement = lockMovement,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
             )
@@ -263,6 +266,7 @@ internal fun SharedTransitionScope.ResizeScreen(
                 width = width,
                 height = height,
                 textColor = textColor,
+                lockMovement = lockMovement,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
             )
@@ -284,10 +288,12 @@ private fun ResizeOverlay(
     width: Int,
     height: Int,
     textColor: TextColor,
+    lockMovement: Boolean,
     onResizeGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
 ) {
@@ -319,6 +325,7 @@ private fun ResizeOverlay(
                 width = width,
                 height = height,
                 color = currentTextColor,
+                lockMovement = lockMovement,
                 onResizeGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
             )
@@ -337,6 +344,7 @@ private fun ResizeOverlay(
                 width = width,
                 height = height,
                 color = currentTextColor,
+                lockMovement = lockMovement,
                 onResizeWidgetGridItem = onResizeGridItem,
                 onResizeEnd = onResizeEnd,
             )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
@@ -63,10 +63,12 @@ internal fun WidgetGridItemResizeOverlay(
     width: Int,
     height: Int,
     color: Color,
+    lockMovement: Boolean,
     onResizeWidgetGridItem: (
         gridItem: GridItem,
         columns: Int,
         rows: Int,
+        lockMovement: Boolean,
     ) -> Unit,
     onResizeEnd: (GridItem) -> Unit,
 ) {
@@ -223,6 +225,7 @@ internal fun WidgetGridItemResizeOverlay(
                 resizingGridItem,
                 columns,
                 rows,
+                lockMovement,
             )
         }
     }

--- a/feature/settings/experimental/src/main/kotlin/com/eblan/launcher/feature/settings/experimental/ExperimentalSettingsScreen.kt
+++ b/feature/settings/experimental/src/main/kotlin/com/eblan/launcher/feature/settings/experimental/ExperimentalSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -44,6 +45,7 @@ import com.eblan.launcher.domain.model.ExperimentalSettings
 import com.eblan.launcher.feature.settings.experimental.dialog.SyncDataDialog
 import com.eblan.launcher.feature.settings.experimental.model.ExperimentalSettingsUiState
 import com.eblan.launcher.ui.settings.SettingsColumn
+import com.eblan.launcher.ui.settings.SettingsSwitch
 
 @Composable
 internal fun ExperimentalSettingsRoute(
@@ -130,6 +132,17 @@ private fun Success(
                 subtitle = "Enable or disable sync data",
                 onClick = {
                     showSyncDataDialog = true
+                },
+            )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
+            SettingsSwitch(
+                checked = experimentalSettings.lockMovement,
+                title = "Lock Movement",
+                subtitle = "Prevent other grid items from moving",
+                onCheckedChange = { lockMovement ->
+                    onUpdateExperimentalSettings(experimentalSettings.copy(lockMovement = lockMovement))
                 },
             )
         }


### PR DESCRIPTION
Closes #316 

This commit introduces a new experimental feature that allows users to "lock" the movement of grid items when dragging or resizing other items on the home screen.

When enabled, this feature prevents other icons and widgets from being pushed aside to make space for the item being moved or resized. If the target area is occupied, the move or resize operation will not complete, and no changes will be made to the grid layout.

### Core Changes:

*   **New Experimental Setting:**
    *   A `lockMovement` boolean has been added to `ExperimentalSettings`.
    *   A new "Lock Movement" switch is now available in the Experimental Settings screen to control this behavior.
    *   The default value for this setting is `false`.

*   **Use Case Modifications:**
    *   `MoveGridItemUseCase` and `ResizeGridItemUseCase` now accept a `lockMovement` boolean parameter.
    *   When `lockMovement` is `true`, these use cases will no longer attempt to resolve conflicts by moving other items. Database updates (`upsertGridItems`) are skipped if this flag is active and a conflict occurs.

*   **UI Integration:**
    *   The `lockMovement` setting is now passed down from `HomeScreen` through `DragScreen` and `ResizeScreen` to the relevant helper functions and overlays.
    *   The `HomeViewModel` has been updated to pass the `lockMovement` flag to the corresponding use cases when a move or resize action is triggered.