### PR TITLE
fix: More Eblan to Einstein naming

### DIFF
--- a/feature/settings/experimental/src/main/kotlin/com/eblan/launcher/feature/settings/experimental/dialog/SyncDataDialog.kt
+++ b/feature/settings/experimental/src/main/kotlin/com/eblan/launcher/feature/settings/experimental/dialog/SyncDataDialog.kt
@@ -58,7 +58,7 @@ internal fun SyncDataDialog(
 
             Text(
                 modifier = Modifier.padding(15.dp),
-                text = "Disabling background sync helps save a bit of memory and keeps things lighter, but it also means Eblan Launcher won’t automatically update your apps, widgets, or shortcuts.\n" +
+                text = "Disabling background sync helps save a bit of memory and keeps things lighter, but it also means Einstein Launcher won’t automatically update your apps, widgets, or shortcuts.\n" +
                     "Your app drawer might show outdated icons, missing widgets, or shortcuts that no longer work.",
             )
 

--- a/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
@@ -144,7 +144,7 @@ internal fun SettingsScreen(
                     SettingsRow(
                         imageVector = EblanLauncherIcons.Info,
                         title = "Default Launcher",
-                        subtitle = "Choose Eblan Launcher",
+                        subtitle = "Choose Einstein Launcher",
                         onClick = {
                             context.startActivity(Intent(ACTION_HOME_SETTINGS))
                         },
@@ -211,12 +211,12 @@ internal fun SettingsScreen(
     if (showSupportDialog) {
         TextDialog(
             title = "Support Development",
-            text = "Thank you for using Eblan Launcher Alpha! I’ve been building this project since January 2025, releasing weekly updates. It’s my most complex project yet, and I pour my heart into it. If you enjoy it, you can support development with a donation or a star on GitHub.",
+            text = "Thank you for using Einstein Launcher Alpha! I’ve been building this project since January 2025, releasing weekly updates. It’s my most complex project yet, and I pour my heart into it. If you enjoy it, you can support development with a donation or a star on GitHub.",
             onClick = {
                 context.startActivity(
                     Intent(
                         Intent.ACTION_VIEW,
-                        "https://github.com/JackEblan/EblanLauncher".toUri(),
+                        "https://github.com/JackEblan/EinsteinLauncher".toUri(),
                     ),
                 )
 


### PR DESCRIPTION
A few more places that need rebranding.

Maybe they should be put into string resources?