### PR TITLE
Fix: Prevent flicker on home screen by rendering only when ready

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -443,90 +443,87 @@ internal fun HomeScreen(
             .fillMaxSize(),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
-            when (homeUiState) {
-                HomeUiState.Loading -> {}
-                is HomeUiState.Success -> {
-                    Success(
-                        screen = screen,
-                        homeData = homeUiState.homeData,
-                        eblanApplicationComponentUiState = eblanApplicationComponentUiState,
-                        pageItems = pageItems,
-                        movedGridItemResult = movedGridItemResult,
-                        screenWidth = screenIntSize.width,
-                        screenHeight = screenIntSize.height,
-                        paddingValues = paddingValues,
-                        dragIntOffset = dragIntOffset,
-                        drag = drag,
-                        foldersDataById = foldersDataById,
-                        eblanApplicationInfosByLabel = eblanApplicationInfosByLabel,
-                        eblanAppWidgetProviderInfosByLabel = eblanAppWidgetProviderInfosByLabel,
-                        gridItemCache = gridItemsCache,
-                        pinGridItem = pinGridItem,
-                        eblanShortcutInfos = eblanShortcutInfos,
-                        eblanShortcutConfigsByLabel = eblanShortcutConfigsByLabel,
-                        eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfos,
-                        iconPackFilePaths = iconPackFilePaths,
-                        onMoveGridItem = onMoveGridItem,
-                        onMoveFolderGridItem = onMoveFolderGridItem,
-                        onResizeGridItem = onResizeGridItem,
-                        onShowGridCache = onShowGridCache,
-                        onShowFolderGridCache = onShowFolderGridCache,
-                        onResetGridCacheAfterResize = onResetGridCacheAfterResize,
-                        onResetGridCacheAfterMove = onResetGridCacheAfterMove,
-                        onCancelGridCache = onCancelGridCache,
-                        onCancelFolderDragGridCache = onCancelFolderDragGridCache,
-                        onEditGridItem = onEditGridItem,
-                        onSettings = onSettings,
-                        onEditPage = onEditPage,
-                        onSaveEditPage = onSaveEditPage,
-                        onUpdateScreen = onUpdateScreen,
-                        onDeleteGridItemCache = onDeleteGridItemCache,
-                        onUpdateGridItemDataCache = onUpdateGridItemDataCache,
-                        onDeleteWidgetGridItemCache = onDeleteWidgetGridItemCache,
-                        onShowFolder = onShowFolder,
-                        onRemoveLastFolder = onRemoveLastFolder,
-                        onAddFolder = onAddFolder,
-                        onResetGridCacheAfterMoveFolder = onResetGridCacheAfterMoveFolder,
-                        onUpdateGridItemImageBitmap = { imageBitmap ->
-                            overlayImageBitmap = imageBitmap
-                        },
-                        onUpdateGridItemOffset = { intOffset, intSize ->
-                            overlayIntOffset = intOffset
+            if (homeUiState is HomeUiState.Success && screenIntSize != IntSize.Zero) {
+                Success(
+                    screen = screen,
+                    homeData = homeUiState.homeData,
+                    eblanApplicationComponentUiState = eblanApplicationComponentUiState,
+                    pageItems = pageItems,
+                    movedGridItemResult = movedGridItemResult,
+                    screenWidth = screenIntSize.width,
+                    screenHeight = screenIntSize.height,
+                    paddingValues = paddingValues,
+                    dragIntOffset = dragIntOffset,
+                    drag = drag,
+                    foldersDataById = foldersDataById,
+                    eblanApplicationInfosByLabel = eblanApplicationInfosByLabel,
+                    eblanAppWidgetProviderInfosByLabel = eblanAppWidgetProviderInfosByLabel,
+                    gridItemCache = gridItemsCache,
+                    pinGridItem = pinGridItem,
+                    eblanShortcutInfos = eblanShortcutInfos,
+                    eblanShortcutConfigsByLabel = eblanShortcutConfigsByLabel,
+                    eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfos,
+                    iconPackFilePaths = iconPackFilePaths,
+                    onMoveGridItem = onMoveGridItem,
+                    onMoveFolderGridItem = onMoveFolderGridItem,
+                    onResizeGridItem = onResizeGridItem,
+                    onShowGridCache = onShowGridCache,
+                    onShowFolderGridCache = onShowFolderGridCache,
+                    onResetGridCacheAfterResize = onResetGridCacheAfterResize,
+                    onResetGridCacheAfterMove = onResetGridCacheAfterMove,
+                    onCancelGridCache = onCancelGridCache,
+                    onCancelFolderDragGridCache = onCancelFolderDragGridCache,
+                    onEditGridItem = onEditGridItem,
+                    onSettings = onSettings,
+                    onEditPage = onEditPage,
+                    onSaveEditPage = onSaveEditPage,
+                    onUpdateScreen = onUpdateScreen,
+                    onDeleteGridItemCache = onDeleteGridItemCache,
+                    onUpdateGridItemDataCache = onUpdateGridItemDataCache,
+                    onDeleteWidgetGridItemCache = onDeleteWidgetGridItemCache,
+                    onShowFolder = onShowFolder,
+                    onRemoveLastFolder = onRemoveLastFolder,
+                    onAddFolder = onAddFolder,
+                    onResetGridCacheAfterMoveFolder = onResetGridCacheAfterMoveFolder,
+                    onUpdateGridItemImageBitmap = { imageBitmap ->
+                        overlayImageBitmap = imageBitmap
+                    },
+                    onUpdateGridItemOffset = { intOffset, intSize ->
+                        overlayIntOffset = intOffset
 
-                            overlayIntSize = intSize
-                        },
-                        onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
-                        onGetEblanAppWidgetProviderInfosByLabel = onGetEblanAppWidgetProviderInfosByLabel,
-                        onGetEblanShortcutConfigsByLabel = onGetEblanShortcutConfigsByLabel,
-                        onDeleteGridItem = onDeleteGridItem,
-                        onUpdateShortcutConfigGridItemDataCache = onUpdateShortcutConfigGridItemDataCache,
-                        onUpdateShortcutConfigIntoShortcutInfoGridItem = onUpdateShortcutConfigIntoShortcutInfoGridItem,
-                        onEditApplicationInfo = onEditApplicationInfo,
-                        onUpdateSharedElementKey = { newSharedElementKey ->
-                            sharedElementKey = newSharedElementKey
-                        },
-                        onMoveGridItemOutsideFolder = onMoveGridItemOutsideFolder,
-                        onShowFolderWhenDragging = onShowFolderWhenDragging,
-                        onResetOverlay = {
-                            overlayIntOffset = IntOffset.Zero
+                        overlayIntSize = intSize
+                    },
+                    onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
+                    onGetEblanAppWidgetProviderInfosByLabel = onGetEblanAppWidgetProviderInfosByLabel,
+                    onGetEblanShortcutConfigsByLabel = onGetEblanShortcutConfigsByLabel,
+                    onDeleteGridItem = onDeleteGridItem,
+                    onUpdateShortcutConfigGridItemDataCache = onUpdateShortcutConfigGridItemDataCache,
+                    onUpdateShortcutConfigIntoShortcutInfoGridItem = onUpdateShortcutConfigIntoShortcutInfoGridItem,
+                    onEditApplicationInfo = onEditApplicationInfo,
+                    onUpdateSharedElementKey = { newSharedElementKey ->
+                        sharedElementKey = newSharedElementKey
+                    },
+                    onMoveGridItemOutsideFolder = onMoveGridItemOutsideFolder,
+                    onShowFolderWhenDragging = onShowFolderWhenDragging,
+                    onResetOverlay = {
+                        overlayIntOffset = IntOffset.Zero
 
-                            overlayIntSize = IntSize.Zero
+                        overlayIntSize = IntSize.Zero
 
-                            overlayImageBitmap = null
+                        overlayImageBitmap = null
 
-                            sharedElementKey = null
-                        },
-                    )
-                }
+                        sharedElementKey = null
+                    },
+                )
+
+                OverlayImage(
+                    overlayIntOffset = overlayIntOffset,
+                    overlayIntSize = overlayIntSize,
+                    overlayImageBitmap = overlayImageBitmap,
+                    sharedElementKey = sharedElementKey,
+                    drag = drag,
+                )
             }
-
-            OverlayImage(
-                overlayIntOffset = overlayIntOffset,
-                overlayIntSize = overlayIntSize,
-                overlayImageBitmap = overlayImageBitmap,
-                sharedElementKey = sharedElementKey,
-                drag = drag,
-            )
         }
     }
 }


### PR DESCRIPTION
Fixes #468 

This commit addresses a flicker issue on the home screen that occurred during initial loading.

Previously, the `Success` composable was rendered inside a `when` block that handled both `Loading` and `Success` states. This could lead to a brief moment where nothing was rendered before the `Success` state was established.

The logic is now changed to use a conditional `if (homeUiState is HomeUiState.Success && screenIntSize != IntSize.Zero)`. This ensures that the `Success` composable and its child components are only composed and rendered when both the UI state is `Success` and the screen dimensions have been measured, preventing any intermediate empty states and eliminating the flicker.