### PR TITLE
Refactor: Extract `GridItem` content into reusable composables

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-01-09T22:53:31.525057757Z">
+        <DropdownSelection timestamp="2026-01-10T23:36:14.753958083Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack115/.android/avd/Pixel_6a.avd" />


### PR DESCRIPTION
This commit refactors the `GridItem.kt` and `InteractiveGridItem.kt` files to improve code reuse and reduce duplication. The content rendering logic for each type of grid item (`ApplicationInfo`, `ShortcutInfo`, `Folder`, `ShortcutConfig`) has been extracted from the interactive and non-interactive composables into new internal `...Content` composables.

This change centralizes the presentation logic, making it easier to maintain and apply consistently across different contexts, such as the main grid and folder previews.

### Key Changes:

*   **New Content Composables:**
    *   Created `ApplicationInfoGridItemContent`, `ShortcutInfoGridItemContent`, `FolderGridItemContent`, and `ShortcutConfigGridItemContent`.
    *   These new functions encapsulate the UI logic (icon, label, badges, etc.) for their respective grid item types.

*   **Refactoring `GridItem.kt` and `InteractiveGridItem.kt`:**
    *   The original `ApplicationInfoGridItem`, `ShortcutInfoGridItem`, `FolderGridItem`, and `ShortcutConfigGridItem` composables (both interactive and static) now call their corresponding `...Content` composable.
    *   This eliminates significant code duplication for rendering the appearance of each item type.
    *   The `...Content` composables handle the core rendering, while the parent composables manage layout, interactivity (gestures, drag state), and shared element transitions.

*   **Code Cleanup:**
    *   The `sharedElementWithCallerManagedVisibility` modifier is now applied more cleanly in the parent composables, wrapping the new content functions.
    *   Removed redundant `OptIn(ExperimentalSharedTransitionApi::class)` annotations where they were no longer directly needed.