### PR TITLE
Refactor: Encapsulate folder state within the `Screen` sealed interface

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreenHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreenHelper.kt
@@ -161,7 +161,7 @@ internal fun handleKlwpBroadcasts(
     }
 
     when (screen) {
-        Screen.Folder -> {
+        is Screen.Folder -> {
             context.sendBroadcast(
                 intent.apply {
                     putExtra(KUSTOM_ACTION_VAR_VALUE, Klwp.Folder.ordinal)
@@ -169,7 +169,7 @@ internal fun handleKlwpBroadcasts(
             )
         }
 
-        Screen.FolderDrag -> {
+        is Screen.FolderDrag -> {
             context.sendBroadcast(
                 intent.apply {
                     putExtra(KUSTOM_ACTION_VAR_VALUE, Klwp.FolderDrag.ordinal)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/grid/GridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/grid/GridItem.kt
@@ -336,21 +336,15 @@ internal fun SharedTransitionScope.FolderGridItemContent(
                 .sortedWith(compareBy({ it.startRow }, { it.startColumn }))
                 .forEach { gridItem ->
                     val folderGridItemModifier = Modifier
-                        .run {
-                            if (screen == Screen.Drag || screen == Screen.FolderDrag) {
-                                sharedElementWithCallerManagedVisibility(
-                                    rememberSharedContentState(
-                                        key = SharedElementKey(
-                                            id = gridItem.id,
-                                            screen = screen,
-                                        ),
-                                    ),
-                                    visible = drag == Drag.Cancel || drag == Drag.End,
-                                )
-                            } else {
-                                this
-                            }
-                        }
+                        .sharedElementWithCallerManagedVisibility(
+                            rememberSharedContentState(
+                                key = SharedElementKey(
+                                    id = gridItem.id,
+                                    screen = screen,
+                                ),
+                            ),
+                            visible = drag == Drag.Cancel || drag == Drag.End,
+                        )
                         .size((gridItemSettings.iconSize * 0.25).dp)
 
                     when (val currentData = gridItem.data) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/Screen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/Screen.kt
@@ -17,12 +17,20 @@
  */
 package com.eblan.launcher.feature.home.model
 
-internal enum class Screen {
-    Pager,
-    Drag,
-    Resize,
-    Loading,
-    EditPage,
-    Folder,
-    FolderDrag,
+import com.eblan.launcher.domain.model.FolderDataById
+
+internal sealed interface Screen {
+    data object Pager : Screen
+
+    data object Drag : Screen
+
+    data object Resize : Screen
+
+    data object Loading : Screen
+
+    data object EditPage : Screen
+
+    data class Folder(val folderDataById: FolderDataById) : Screen
+
+    data class FolderDrag(val folderDataById: FolderDataById) : Screen
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragGridItemHelper.kt
@@ -252,7 +252,6 @@ internal suspend fun handleConflictingGridItem(
     drag: Drag,
     moveGridItemResult: MoveGridItemResult?,
     onShowFolderWhenDragging: (String) -> Unit,
-    onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
     delay(1500L)
 
@@ -263,13 +262,6 @@ internal suspend fun handleConflictingGridItem(
     val conflictingGridItem = moveGridItemResult.conflictingGridItem
 
     if (conflictingGridItem != null) {
-        onUpdateSharedElementKey(
-            SharedElementKey(
-                id = moveGridItemResult.movingGridItem.id,
-                screen = Screen.FolderDrag,
-            ),
-        )
-
         onShowFolderWhenDragging(conflictingGridItem.id)
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/drag/DragScreen.kt
@@ -354,7 +354,6 @@ internal fun SharedTransitionScope.DragScreen(
             drag = drag,
             moveGridItemResult = moveGridItemResult,
             onShowFolderWhenDragging = onShowFolderWhenDragging,
-            onUpdateSharedElementKey = onUpdateSharedElementKey,
         )
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folderdrag/FolderDragScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -70,7 +70,7 @@ import com.eblan.launcher.feature.home.util.getSystemTextColor
 @Composable
 internal fun SharedTransitionScope.FolderDragScreen(
     modifier: Modifier = Modifier,
-    foldersDataById: ArrayDeque<FolderDataById>,
+    folderDataById: FolderDataById,
     gridItemCache: GridItemCache,
     gridItemSource: GridItemSource?,
     textColor: TextColor,
@@ -81,7 +81,6 @@ internal fun SharedTransitionScope.FolderDragScreen(
     paddingValues: PaddingValues,
     homeSettings: HomeSettings,
     moveGridItemResult: MoveGridItemResult?,
-    folderGridHorizontalPagerState: PagerState,
     statusBarNotifications: Map<String, Int>,
     hasShortcutHostPermission: Boolean,
     iconPackFilePaths: Map<String, String>,
@@ -122,7 +121,11 @@ internal fun SharedTransitionScope.FolderDragScreen(
 
     var titleHeight by remember { mutableIntStateOf(0) }
 
-    val folderDataById = requireNotNull(foldersDataById.lastOrNull())
+    val folderGridHorizontalPagerState = rememberPagerState(
+        pageCount = {
+            folderDataById.pageCount
+        },
+    )
 
     LaunchedEffect(key1 = drag, key2 = dragIntOffset) {
         handleDragFolderGridItem(


### PR DESCRIPTION
This commit refactors the handling of folder data and screen state by moving folder-related data directly into the `Screen` sealed interface. Previously, folder data was managed separately in the `HomeViewModel` via a `foldersDataById` StateFlow. Now, the `Folder` and `FolderDrag` states are data classes that hold their own `FolderDataById`, simplifying state management and making the UI more robust.

This change decouples the `FolderScreen` and `FolderDragScreen` from the ViewModel's `ArrayDeque` of folders, allowing them to be more self-contained and receive their necessary data directly through the `Screen` state.

### Key Changes:

*   **`Screen` Sealed Interface:**
    *   The `Screen` enum has been converted into a `sealed interface`.
    *   `Screen.Folder` and `Screen.FolderDrag` are now `data class` instances, each holding a `folderDataById: FolderDataById` property. This encapsulates the data required for rendering the respective screen.

*   **ViewModel Simplification:**
    *   The public `foldersDataById` `StateFlow` has been removed from `HomeViewModel`. The `_foldersDataById` `ArrayDeque` is now fully internal to the ViewModel for state logic.
    *   Functions like `showFolder`, `addFolder`, and `resetGridCacheAfterMoveFolder` now update the `_screen` StateFlow with the appropriate `Screen.Folder` or `Screen.FolderDrag` instance, passing the relevant `FolderDataById`.
    *   The logic for handling folder navigation (adding/removing folders) is now more tightly integrated with screen state transitions.

*   **Composable Updates:**
    *   `FolderScreen` and `FolderDragScreen` no longer receive the entire `foldersDataById` `ArrayDeque`. Instead, they accept a single `folderDataById: FolderDataById` object from their respective `Screen` data class.
    *   The `rememberPagerState` for the folder's horizontal pager is now created within `FolderScreen` and `FolderDragScreen` since they have direct access to the `pageCount` from `folderDataById`.
    *   Removed `AnimatedContent` from `FolderScreen` as it is no longer needed; the transition is handled by the parent `AnimatedContent` observing the `screen` state.

*   **Cleanup and Minor Refinements:**
    *   Unnecessary parameters like `onUpdateSharedElementKey` were removed from `handleDragGridItem`.
    *   The `sharedElement` logic in `GridItem.kt` was simplified by removing a conditional `run` block, as the modifier is always applied in drag scenarios.
    *   The `onShowFolderGridCache` callback signature was simplified to no longer require a `Screen` parameter.