### PR TITLE
Refactor: Use hash code for icon pack filenames

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/GetIconPackFilePathsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/GetIconPackFilePathsUseCase.kt
@@ -54,10 +54,7 @@ class GetIconPackFilePathsUseCase @Inject constructor(
             eblaApplicationInfos.mapNotNull { eblanApplicationInfo ->
                 val iconPackFile = File(
                     iconPackDirectory,
-                    eblanApplicationInfo.componentName.replace(
-                        "/",
-                        "-",
-                    ),
+                    eblanApplicationInfo.componentName.hashCode().toString(),
                 )
 
                 if (iconPackFile.exists()) {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
@@ -72,10 +72,7 @@ class UpdateIconPackInfosUseCase @Inject constructor(
                     .map { launcherAppsActivityInfo ->
                         ensureActive()
 
-                        launcherAppsActivityInfo.componentName.replace(
-                            "/",
-                            "-",
-                        )
+                        launcherAppsActivityInfo.componentName.hashCode().toString()
                     }
 
                 eblanIconPackInfoRepository.upsertEblanIconPackInfo(


### PR DESCRIPTION
Fixes #515 

This commit changes the filename generation logic for icon pack files to use the `hashCode()` of the component name instead of replacing characters.

Using the hash code of the `componentName` string (`componentName.hashCode().toString()`) provides a consistent and more file-system-friendly naming scheme compared to the previous method of replacing "/" with "-". This change affects both the creation and retrieval of icon pack files.

### Key Changes:

*   **`UpdateIconPackInfosUseCase.kt`:** When generating and saving icon pack information, the filename for each icon is now derived from the hash code of the `launcherAppsActivityInfo.componentName`.
*   **`GetIconPackFilePathsUseCase.kt`:** When looking up existing icon pack files, the logic is updated to use the same `componentName.hashCode().toString()` method to construct the expected filename, ensuring it can locate the files created by the updated logic.