### PR TITLE
Add the ability of toggle search bar in app drawer

### DIFF
--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -74,6 +74,7 @@ internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = A
     appDrawerColumns = appDrawerColumns,
     appDrawerRowsHeight = appDrawerRowsHeight,
     gridItemSettings = gridItemSettingsProto.toGridItemSettings(),
+    showSearchBar = if (hasShowSearchBar()) showSearchBar else true,
 )
 
 internal fun GridItemSettingsProto.toGridItemSettings(): GridItemSettings = GridItemSettings(
@@ -237,6 +238,7 @@ internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProt
         .setAppDrawerColumns(appDrawerColumns)
         .setAppDrawerRowsHeight(appDrawerRowsHeight)
         .setGridItemSettingsProto(gridItemSettingsProto)
+        .setShowSearchBar(showSearchBar)
         .build()
 }
 

--- a/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
+++ b/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
@@ -9,4 +9,5 @@ message AppDrawerSettingsProto {
   int32 appDrawerColumns = 1;
   int32 appDrawerRowsHeight = 2;
   GridItemSettingsProto gridItemSettingsProto = 3;
+  optional bool showSearchBar = 4;
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
@@ -21,4 +21,5 @@ data class AppDrawerSettings(
     val appDrawerColumns: Int,
     val appDrawerRowsHeight: Int,
     val gridItemSettings: GridItemSettings,
+    val showSearchBar: Boolean = true,
 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -324,10 +324,12 @@ private fun SharedTransitionScope.Success(
                 end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
             ),
     ) {
-        SearchBar(
-            title = "Search Applications",
-            onChangeLabel = onGetEblanApplicationInfosByLabel,
-        )
+        if (appDrawerSettings.showSearchBar) {
+            SearchBar(
+                title = "Search Applications",
+                onChangeLabel = onGetEblanApplicationInfosByLabel,
+            )
+        }
 
         if (getEblanApplicationInfos.eblanApplicationInfos.keys.size > 1) {
             EblanApplicationInfoTabRow(

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -149,6 +149,18 @@ private fun Success(
             HorizontalDivider(modifier = Modifier.fillMaxWidth())
 
             SettingsColumn(
+                title = "Show Search Bar",
+                subtitle = if (appDrawerSettings.showSearchBar) "Enabled" else "Disabled",
+                onClick = {
+                    onUpdateAppDrawerSettings(
+                        appDrawerSettings.copy(showSearchBar = !appDrawerSettings.showSearchBar)
+                    )
+                },
+            )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
+            SettingsColumn(
                 title = "Hidden Applications",
                 subtitle = "Hidden Applications",
                 onClick = {


### PR DESCRIPTION
This is useful for people who have fewer apps or who simply don’t use the search bar or don’t want to see it at all