### PR TITLE
Refactor: Improve icon pack component matching logic

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/IconPackInfoUseCaseUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/IconPackInfoUseCaseUtil.kt
@@ -29,13 +29,12 @@ internal suspend fun cacheIconPackFile(
     iconPackInfoPackageName: String,
     iconPackInfoDirectory: File,
     componentName: String,
-    packageName: String,
 ) {
     appFilter.find { iconPackInfoComponent ->
         currentCoroutineContext().ensureActive()
 
-        iconPackInfoComponent.component.contains(componentName) ||
-            iconPackInfoComponent.component.contains(packageName)
+        componentName == iconPackInfoComponent.component.removePrefix("ComponentInfo{")
+            .removeSuffix("}")
     }?.let { iconPackInfoComponent ->
         iconPackManager.createIconPackInfoPath(
             packageName = iconPackInfoPackageName,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfoByPackageNameUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfoByPackageNameUseCase.kt
@@ -56,7 +56,6 @@ class UpdateIconPackInfoByPackageNameUseCase @Inject constructor(
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     iconPackInfoDirectory = iconPackDirectory,
                     componentName = componentName,
-                    packageName = packageName,
                 )
             }
         }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
@@ -66,7 +66,6 @@ class UpdateIconPackInfosUseCase @Inject constructor(
                             iconPackInfoPackageName = iconPackInfoPackageName,
                             iconPackInfoDirectory = iconPackDirectory,
                             componentName = launcherAppsActivityInfo.componentName,
-                            packageName = launcherAppsActivityInfo.packageName,
                         )
                     }
                     .map { launcherAppsActivityInfo ->

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -440,7 +440,6 @@ class SyncDataUseCase @Inject constructor(
                         iconPackInfoPackageName = iconPackInfoPackageName,
                         iconPackInfoDirectory = iconPackDirectory,
                         componentName = launcherAppsActivityInfo.componentName,
-                        packageName = launcherAppsActivityInfo.packageName,
                     )
                 }.map { launcherAppsActivityInfo ->
                     currentCoroutineContext().ensureActive()


### PR DESCRIPTION
Fixes #519

This commit refactors the logic for matching application components with icon pack definitions, making it more precise and removing redundant code.

The previous implementation used a simple `contains` check on the `packageName`, which could lead to incorrect icon assignments if multiple packages had similar names (e.g., `com.example.app` and `com.example.app.pro`). The logic has now been updated to perform an exact match on the full `componentName`.

### Key Changes:

*   **Precise Component Matching:**
    *   In `IconPackInfoUseCaseUtil.kt`, the matching logic has been changed from `iconPackInfoComponent.component.contains(componentName)` to an exact comparison: `componentName == iconPackInfoComponent.component.removePrefix("ComponentInfo{").removeSuffix("}")`. This ensures that the correct icon from the icon pack is applied to the corresponding application component.

*   **Redundant Code Removal:**
    *   The unused `packageName` parameter has been removed from the function signature in `IconPackInfoUseCaseUtil.kt` as it is no longer needed for the improved matching logic.
    *   Correspondingly, the `packageName` argument has been removed from calls to this utility in:
        *   `SyncDataUseCase.kt`
        *   `UpdateIconPackInfosUseCase.kt`
        *   `UpdateIconPackInfoByPackageNameUseCase.kt`