### PR TITLE
Refactor: Use service context for BroadcastReceiver registration

### DIFF
--- a/service/src/main/kotlin/com/eblan/launcher/service/EblanAccessibilityService.kt
+++ b/service/src/main/kotlin/com/eblan/launcher/service/EblanAccessibilityService.kt
@@ -63,12 +63,10 @@ internal class EblanAccessibilityService : AccessibilityService() {
     }
 
     override fun onServiceConnected() {
-        val intentFilter = IntentFilter(GlobalAction.NAME)
-
         ContextCompat.registerReceiver(
-            applicationContext,
+            this,
             globalActionBroadcastReceiver,
-            intentFilter,
+            IntentFilter(GlobalAction.NAME),
             ContextCompat.RECEIVER_NOT_EXPORTED,
         )
     }


### PR DESCRIPTION
Fixes #531 

This commit updates how the `globalActionBroadcastReceiver` is registered within the `EblanAccessibilityService`.

The `ContextCompat.registerReceiver` call now uses the service's `this` as the `Context` instead of the `applicationContext`. This is a more appropriate and direct context for a receiver tied to the service's lifecycle.

Additionally, the `IntentFilter` is now created inline within the `registerReceiver` call, slightly simplifying the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure in the accessibility service without impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->