### PR TITLE
Fix: Correctly position widget resize overlay during drag operations

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
@@ -125,7 +125,7 @@ internal fun WidgetGridItemResizeOverlay(
                     (x + width) - dragHandleSizePx
                 }
             } else {
-                x
+                currentX.value.roundToInt()
             }
         }
     }
@@ -139,7 +139,7 @@ internal fun WidgetGridItemResizeOverlay(
                     (y + height) - dragHandleSizePx
                 }
             } else {
-                y
+                currentY.value.roundToInt()
             }
         }
     }


### PR DESCRIPTION
Fixes #565 

This commit fixes a UI bug in the widget resizing overlay where the overlay's position would not update correctly while being dragged.

The `currentWidth` and `currentHeight` calculations previously used static `x` and `y` coordinates in their `else` block, which caused the overlay to jump back to its initial position during a drag gesture.

This has been corrected by using the dynamic `currentX` and `currentY` state values instead, ensuring the overlay's position and size are calculated based on its current location during the drag.

### Key Changes:

*   **`WidgetGridItemResizeOverlay.kt`:**
    *   The `currentWidth` calculation now uses `currentX.value.roundToInt()` instead of `x` when not resizing from the right handle.
    *   The `currentHeight` calculation now uses `currentY.value.roundToInt()` instead of `y` when not resizing from the bottom handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced widget resize overlay behavior. Border positions now accurately reflect the live animation during resizing operations, providing better visual feedback when dragging from different resize points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->