### PR TITLE
Fix: Icons are missing when updating applications

### DIFF
--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
@@ -23,6 +23,7 @@ import com.eblan.launcher.data.room.dao.EblanApplicationInfoDao
 import com.eblan.launcher.data.room.entity.EblanApplicationInfoTagEntity
 import com.eblan.launcher.domain.common.dispatcher.Dispatcher
 import com.eblan.launcher.domain.common.dispatcher.EblanDispatchers
+import com.eblan.launcher.domain.model.DeleteEblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfoTag
 import com.eblan.launcher.domain.model.SyncEblanApplicationInfo
@@ -76,8 +77,8 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
         eblanApplicationInfoDao.upsertSyncEblanApplicationInfoEntities(syncEblanApplicationInfos = syncEblanApplicationInfos)
     }
 
-    override suspend fun deleteSyncEblanApplicationInfos(syncEblanApplicationInfos: List<SyncEblanApplicationInfo>) {
-        eblanApplicationInfoDao.deleteSyncEblanApplicationInfoEntities(syncEblanApplicationInfos = syncEblanApplicationInfos)
+    override suspend fun deleteSyncEblanApplicationInfos(deleteEblanApplicationInfos: List<DeleteEblanApplicationInfo>) {
+        eblanApplicationInfoDao.deleteSyncEblanApplicationInfoEntities(deleteEblanApplicationInfos = deleteEblanApplicationInfos)
     }
 
     override suspend fun updateEblanApplicationInfo(eblanApplicationInfo: EblanApplicationInfo) {

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoDao.kt
@@ -24,6 +24,7 @@ import androidx.room.Update
 import androidx.room.Upsert
 import com.eblan.launcher.data.room.entity.EblanApplicationInfoEntity
 import com.eblan.launcher.data.room.entity.EblanApplicationInfoTagEntity
+import com.eblan.launcher.domain.model.DeleteEblanApplicationInfo
 import com.eblan.launcher.domain.model.SyncEblanApplicationInfo
 import kotlinx.coroutines.flow.Flow
 
@@ -54,7 +55,7 @@ interface EblanApplicationInfoDao {
     suspend fun upsertSyncEblanApplicationInfoEntities(syncEblanApplicationInfos: List<SyncEblanApplicationInfo>)
 
     @Delete(entity = EblanApplicationInfoEntity::class)
-    suspend fun deleteSyncEblanApplicationInfoEntities(syncEblanApplicationInfos: List<SyncEblanApplicationInfo>)
+    suspend fun deleteSyncEblanApplicationInfoEntities(deleteEblanApplicationInfos: List<DeleteEblanApplicationInfo>)
 
     @Update
     suspend fun updateEblanApplicationInfoEntity(entity: EblanApplicationInfoEntity)

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/DeleteEblanApplicationInfo.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/DeleteEblanApplicationInfo.kt
@@ -1,0 +1,25 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.model
+
+data class DeleteEblanApplicationInfo(
+    val serialNumber: Long,
+    val componentName: String,
+    val packageName: String,
+    val icon: String?,
+)

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/EblanApplicationInfoRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/EblanApplicationInfoRepository.kt
@@ -17,6 +17,7 @@
  */
 package com.eblan.launcher.domain.repository
 
+import com.eblan.launcher.domain.model.DeleteEblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfoTag
 import com.eblan.launcher.domain.model.SyncEblanApplicationInfo
@@ -38,7 +39,7 @@ interface EblanApplicationInfoRepository {
 
     suspend fun upsertSyncEblanApplicationInfos(syncEblanApplicationInfos: List<SyncEblanApplicationInfo>)
 
-    suspend fun deleteSyncEblanApplicationInfos(syncEblanApplicationInfos: List<SyncEblanApplicationInfo>)
+    suspend fun deleteSyncEblanApplicationInfos(deleteEblanApplicationInfos: List<DeleteEblanApplicationInfo>)
 
     suspend fun updateEblanApplicationInfo(eblanApplicationInfo: EblanApplicationInfo)
 

--- a/framework/image-serializer/src/main/kotlin/com/eblan/launcher/framework/imageserializer/DefaultImageSerializer.kt
+++ b/framework/image-serializer/src/main/kotlin/com/eblan/launcher/framework/imageserializer/DefaultImageSerializer.kt
@@ -92,7 +92,7 @@ internal class DefaultImageSerializer @Inject constructor(
         file: File,
     ) {
         withContext(ioDispatcher) {
-            val bitmap: Bitmap = when (drawable) {
+            val bitmap = when (drawable) {
                 is BitmapDrawable -> drawable.bitmap
 
                 else -> {


### PR DESCRIPTION
#533 

This commit refactors the application info deletion process in `SyncDataUseCase` and `ChangePackageUseCase` by introducing a new data class, `DeleteEblanApplicationInfo`. This improves type safety and clarifies the intent of delete operations.

Previously, the `deleteSyncEblanApplicationInfos` method in the DAO and repository layers accepted `SyncEblanApplicationInfo`, which was semantically incorrect as it was being used for deletion. This has been corrected to use the new, more specific `DeleteEblanApplicationInfo` model, making the code easier to understand and maintain.

### Key Changes:

*   **New `DeleteEblanApplicationInfo` Data Class:**
    *   A new `DeleteEblanApplicationInfo` data class has been created to explicitly represent an application that is marked for deletion.

*   **Updated Deletion Logic:**
    *   In `SyncDataUseCase` and `ChangePackageUseCase`, the logic now maps `SyncEblanApplicationInfo` objects to the new `DeleteEblanApplicationInfo` type before passing them to the repository for deletion.
    *   The `EblanApplicationInfoRepository` and `EblanApplicationInfoDao` interfaces have been updated to accept `List<DeleteEblanApplicationInfo>` in their deletion methods, enforcing stricter type correctness.

*   **Code Cleanup:**
    *   Removed a redundant check for unique package names in `ChangePackageUseCase` when deleting `EblanShortcutConfig` icons, as it was no longer necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application deletion and data cleanup workflows with refined internal handling for better system reliability and consistency.
  * Streamlined code structure and removed unnecessary checks in cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->