### PR TITLE
Improved drag-to-dismiss gesture constraints in `PagerScreenState`

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -1133,7 +1133,7 @@ internal class PagerScreenState(
 
     fun verticalDragApplicationScreen(dragAmount: Float) {
         scope.launch {
-            swipeY.snapTo(swipeY.value + dragAmount)
+            swipeY.snapTo((swipeY.value + dragAmount).coerceIn(0f, screenHeight.toFloat()))
         }
     }
 
@@ -1165,13 +1165,23 @@ internal class PagerScreenState(
 
     fun verticalDragWidgetScreen(dragAmount: Float) {
         scope.launch {
-            widgetScreenOffsetY.snapTo(widgetScreenOffsetY.value + dragAmount)
+            widgetScreenOffsetY.snapTo(
+                (widgetScreenOffsetY.value + dragAmount).coerceIn(
+                    0f,
+                    screenHeight.toFloat(),
+                ),
+            )
         }
     }
 
     fun verticalDragShortcutConfigScreen(dragAmount: Float) {
         scope.launch {
-            shortcutConfigScreenOffsetY.snapTo(shortcutConfigScreenOffsetY.value + dragAmount)
+            shortcutConfigScreenOffsetY.snapTo(
+                (shortcutConfigScreenOffsetY.value + dragAmount).coerceIn(
+                    0f,
+                    screenHeight.toFloat(),
+                ),
+            )
         }
     }
 
@@ -1233,7 +1243,12 @@ internal class PagerScreenState(
 
     fun verticalDragAppWidgetScreen(dragAmount: Float) {
         scope.launch {
-            appWidgetScreenOffsetY.snapTo(appWidgetScreenOffsetY.value + dragAmount)
+            appWidgetScreenOffsetY.snapTo(
+                (appWidgetScreenOffsetY.value + dragAmount).coerceIn(
+                    0f,
+                    screenHeight.toFloat(),
+                ),
+            )
         }
     }
 
@@ -1316,9 +1331,11 @@ internal class PagerScreenState(
                     val shortcutInfo = pinItemRequest.shortcutInfo
 
                     if (shortcutInfo != null) {
-                        val serialNumber = androidUserManagerWrapper.getSerialNumberForUser(userHandle = shortcutInfo.userHandle)
+                        val serialNumber =
+                            androidUserManagerWrapper.getSerialNumberForUser(userHandle = shortcutInfo.userHandle)
 
-                        val shortcutIconKey = "$serialNumber:${shortcutInfo.`package`}:${shortcutInfo.id}"
+                        val shortcutIconKey =
+                            "$serialNumber:${shortcutInfo.`package`}:${shortcutInfo.id}"
 
                         val icon = androidLauncherAppsWrapper.getShortcutBadgedIconDrawable(
                             shortcutInfo = shortcutInfo,


### PR DESCRIPTION
Fixes #664 

- Added value clamping to `verticalDragApplicationScreen`, `verticalDragWidgetScreen`, `verticalDragShortcutConfigScreen`, and `verticalDragAppWidgetScreen` to prevent screens from being dragged beyond the screen boundaries (clamped between `0f` and `screenHeight`).
- Minor code formatting in `PagerScreenState` for shortcut icon key generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag behavior on pager screens to properly constrain content within screen boundaries, preventing offsets from extending beyond the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->