### PR TITLE
Added a "Show Keyboard" setting to the application drawer

### DIFF
--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -68,6 +68,7 @@ internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = A
     eblanApplicationInfoOrder = eblanApplicationInfoOrderProto.toEblanApplicationInfoOrder(),
     backgroundColor = backgroundColor.toTextColor(),
     customBackgroundColor = customBackgroundColor,
+    showKeyboard = showKeyboard,
 )
 
 internal fun GridItemSettingsProto.toGridItemSettings(): GridItemSettings = GridItemSettings(
@@ -111,6 +112,7 @@ internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProt
     .setEblanApplicationInfoOrderProto(eblanApplicationInfoOrder.toEblanApplicationInfoOrderProto())
     .setBackgroundColor(backgroundColor.toTextColorProto())
     .setCustomBackgroundColor(customBackgroundColor)
+    .setShowKeyboard(showKeyboard)
     .build()
 
 internal fun GeneralSettings.toGeneralSettingsProto(): GeneralSettingsProto = GeneralSettingsProto.newBuilder().setThemeProto(theme.toThemeProto())

--- a/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
+++ b/data/datastore/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
@@ -14,4 +14,5 @@ message AppDrawerSettingsProto {
   EblanApplicationInfoOrderProto eblanApplicationInfoOrderProto = 4;
   TextColorProto backgroundColor = 5;
   int32 customBackgroundColor = 6;
+  bool showKeyboard = 7;
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
@@ -24,4 +24,5 @@ data class AppDrawerSettings(
     val eblanApplicationInfoOrder: EblanApplicationInfoOrder,
     val backgroundColor: TextColor,
     val customBackgroundColor: Int,
+    val showKeyboard: Boolean,
 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -90,6 +90,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -100,6 +102,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -412,11 +415,12 @@ private fun SharedTransitionScope.Success(
             ),
     ) {
         ApplicationSearchBar(
-            modifier = modifier,
             searchBarState = searchBarState,
             textFieldState = textFieldState,
             backgroundColor = appDrawerSettings.backgroundColor,
             customBackgroundColor = appDrawerSettings.customBackgroundColor,
+            swipeY = swipeY,
+            showKeyboard = appDrawerSettings.showKeyboard,
             onUpdateShowEblanApplicationInfoOrderDialog = { newShowEblanApplicationInfoOrderDialog ->
                 showEblanApplicationInfoOrderDialog = newShowEblanApplicationInfoOrderDialog
             },
@@ -612,9 +616,15 @@ private fun ApplicationSearchBar(
     textFieldState: TextFieldState,
     backgroundColor: TextColor,
     customBackgroundColor: Int,
+    swipeY: Float,
+    showKeyboard: Boolean,
     onUpdateShowEblanApplicationInfoOrderDialog: (Boolean) -> Unit,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     val scope = rememberCoroutineScope()
+
+    val focusRequester = remember { FocusRequester() }
 
     val searchBarContainerColor = when (backgroundColor) {
         TextColor.System -> {
@@ -669,9 +679,19 @@ private fun ApplicationSearchBar(
             Color(customBackgroundColor)
         }
     }
+
+    LaunchedEffect(key1 = swipeY) {
+        if (swipeY.roundToInt() == 0 && showKeyboard) {
+            focusRequester.requestFocus()
+
+            keyboardController?.show()
+        }
+    }
+
     SearchBar(
         state = searchBarState,
         modifier = modifier
+            .focusRequester(focusRequester)
             .fillMaxWidth()
             .padding(10.dp),
         inputField = {

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -51,6 +51,7 @@ import com.eblan.launcher.ui.dialog.TextColorDialog
 import com.eblan.launcher.ui.dialog.TwoTextFieldsDialog
 import com.eblan.launcher.ui.settings.GridItemSettings
 import com.eblan.launcher.ui.settings.SettingsColumn
+import com.eblan.launcher.ui.settings.SettingsSwitch
 import com.eblan.launcher.ui.settings.TextColorSettingsRow
 
 @Composable
@@ -147,6 +148,17 @@ private fun Success(
                 subtitle = "${appDrawerSettings.appDrawerColumns}x${appDrawerSettings.appDrawerRowsHeight}",
                 onClick = {
                     showGridDialog = true
+                },
+            )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
+            SettingsSwitch(
+                checked = appDrawerSettings.showKeyboard,
+                title = "Show Keyboard",
+                subtitle = "Show keyboard on launch",
+                onCheckedChange = { showKeyboard ->
+                    onUpdateAppDrawerSettings(appDrawerSettings.copy(showKeyboard = showKeyboard))
                 },
             )
 


### PR DESCRIPTION
Closes #662 

- Updated `app_drawer_settings.proto` and `AppDrawerSettings` model to include a `showKeyboard` boolean flag.
- Implemented the `showKeyboard` toggle in `AppDrawerSettingsScreen`.
- Updated `DataStoreMapper` to handle the new `showKeyboard` field during serialization and deserialization.
- Refactored `ApplicationSearchBar` in `ApplicationScreen` to automatically request focus and display the software keyboard when the drawer is fully opened, contingent on the `showKeyboard` setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard visibility control in app drawer settings - users can now toggle whether the software keyboard automatically appears when accessing the app drawer. This new configurable option provides enhanced customization of keyboard behavior within the launcher experience, allowing users to optimize their interaction based on personal preference when browsing and searching for applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->