### PR TITLE
Reset App Drawer State

### DIFF
--- a/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
+++ b/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
@@ -19,4 +19,5 @@ message AppDrawerSettingsProto {
   AppDrawerTypeProto AppDrawerTypeProto = 8;
   int32 horizontalAppDrawerColumns = 9;
   int32 horizontalAppDrawerRows = 10;
+  bool resetState = 11;
 }

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -74,6 +74,7 @@ internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = A
     appDrawerType = appDrawerTypeProto.toAppDrawerType(),
     horizontalAppDrawerColumns = horizontalAppDrawerColumns,
     horizontalAppDrawerRows = horizontalAppDrawerRows,
+    resetState = resetState,
 )
 
 internal fun GridItemSettingsProto.toGridItemSettings(): GridItemSettings = GridItemSettings(
@@ -121,6 +122,7 @@ internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProt
     .setAppDrawerTypeProto(appDrawerType.toAppDrawerTypeProto())
     .setHorizontalAppDrawerColumns(horizontalAppDrawerColumns)
     .setHorizontalAppDrawerRows(horizontalAppDrawerRows)
+    .setResetState(resetState)
     .build()
 
 internal fun GeneralSettings.toGeneralSettingsProto(): GeneralSettingsProto = GeneralSettingsProto.newBuilder().setThemeProto(theme.toThemeProto())

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
@@ -28,4 +28,5 @@ data class AppDrawerSettings(
     val appDrawerType: AppDrawerType,
     val horizontalAppDrawerColumns: Int,
     val horizontalAppDrawerRows: Int,
+    val resetState: Boolean,
 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -727,6 +727,8 @@ internal fun ApplicationScreenEffect(
     onUpdateSelectedEblanApplicationInfoTagId: (Long?) -> Unit,
     onResetScroll: () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+
     LaunchedEffect(key1 = textFieldState) {
         snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
             if (text.isNotEmpty()) {
@@ -745,9 +747,18 @@ internal fun ApplicationScreenEffect(
             onGetEblanApplicationInfosByLabel("")
 
             textFieldState.clearText()
+        }
 
+        if (swipeY.roundToInt() >= screenHeight &&
+            selectedEblanApplicationInfoTagId != null &&
+            appDrawerSettings.resetState
+        ) {
             onUpdateSelectedEblanApplicationInfoTagId(null)
+        }
 
+        if (swipeY.roundToInt() >= screenHeight &&
+            appDrawerSettings.resetState
+        ) {
             onResetScroll()
         }
 
@@ -764,12 +775,14 @@ internal fun ApplicationScreenEffect(
     }
 
     LaunchedEffect(key1 = isPressHome) {
-        if (isPressHome) {
+        if (isPressHome && showPopupApplicationMenu) {
             onShowPopupApplicationMenu(false)
 
-            searchBarState.animateToCollapsed()
-
             onDismiss()
+        }
+
+        if (isPressHome && searchBarState.currentValue == SearchBarValue.Expanded) {
+            searchBarState.animateToCollapsed()
         }
 
         if (isPressHome && appDrawerSettings.resetState) {
@@ -790,12 +803,20 @@ internal fun ApplicationScreenEffect(
     }
 
     BackHandler(enabled = swipeY < screenHeight.toFloat()) {
-        if (appDrawerSettings.resetState) {
-            onResetScroll()
+        scope.launch {
+            if (showPopupApplicationMenu) {
+                onShowPopupApplicationMenu(false)
+            }
+
+            if (searchBarState.currentValue == SearchBarValue.Expanded) {
+                searchBarState.animateToCollapsed()
+            }
+
+            onDismiss()
+
+            if (appDrawerSettings.resetState) {
+                onResetScroll()
+            }
         }
-
-        onShowPopupApplicationMenu(false)
-
-        onDismiss()
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -771,9 +771,11 @@ internal fun ApplicationScreenEffect(
 
             searchBarState.animateToCollapsed()
 
-            onScrollItem(0)
-
             onDismiss()
+        }
+
+        if (isPressHome && appDrawerSettings.resetState) {
+            onScrollItem(0)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -20,6 +20,7 @@ package com.eblan.launcher.feature.home.screen.application
 import android.graphics.Rect
 import android.os.Build
 import android.os.UserHandle
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
@@ -34,13 +35,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.material3.ElevatedFilterChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SearchBarState
+import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
@@ -52,6 +58,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -108,6 +115,11 @@ import com.eblan.launcher.feature.home.util.getVerticalArrangement
 import com.eblan.launcher.framework.packagemanager.AndroidPackageManagerWrapper
 import com.eblan.launcher.framework.usermanager.AndroidUserManagerWrapper
 import com.eblan.launcher.ui.local.LocalLauncherApps
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.uuid.ExperimentalUuidApi
@@ -375,6 +387,7 @@ internal fun SharedTransitionScope.EblanApplicationInfoItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
+    onScrollToItem: suspend (Int) -> Unit,
 ) {
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
@@ -506,6 +519,14 @@ internal fun SharedTransitionScope.EblanApplicationInfoItem(
                                 sourceBoundsY + intSize.height,
                             ),
                         )
+
+                        if (appDrawerSettings.resetState) {
+                            scope.launch {
+                                onDismiss()
+
+                                onScrollToItem(0)
+                            }
+                        }
                     },
                     onLongPress = {
                         scope.launch {
@@ -642,16 +663,13 @@ internal fun TagElevatedFilterChip(
 internal fun EblanApplicationInfoTabRow(
     modifier: Modifier = Modifier,
     currentPage: Int,
+    eblanUserPageKeys: List<EblanUserPageKey>,
     eblanApplicationInfos: Map<EblanUserPageKey, List<EblanApplicationInfo>>,
     onAnimateScrollToPage: suspend (Int) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
 
     val currentEblanUserPageKey = eblanApplicationInfos.keys.toList()[currentPage]
-
-    val eblanUserPageKeys = remember(key1 = eblanApplicationInfos) {
-        eblanApplicationInfos.keys.distinctBy { it.eblanUser.serialNumber }
-    }
 
     val selectedTabIndex = remember(
         key1 = eblanUserPageKeys,
@@ -685,6 +703,101 @@ internal fun EblanApplicationInfoTabRow(
                     )
                 },
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
+@Composable
+internal fun ApplicationScreenEffect(
+    appDrawerSettings: AppDrawerSettings,
+    drag: Drag,
+    horizontalPagerState: PagerState,
+    isPressHome: Boolean,
+    screenHeight: Int,
+    searchBarState: SearchBarState,
+    selectedEblanApplicationInfoTagId: Long?,
+    showPopupApplicationMenu: Boolean,
+    swipeY: Float,
+    textFieldState: TextFieldState,
+    onDismiss: () -> Unit,
+    onGetEblanApplicationInfosByLabel: (String) -> Unit,
+    onGetEblanApplicationInfosByTagId: (Long?) -> Unit,
+    onShowPopupApplicationMenu: (Boolean) -> Unit,
+    onUpdateSelectedEblanApplicationInfoTagId: (Long?) -> Unit,
+    onScrollItem: suspend (Int) -> Unit = {},
+) {
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(key1 = textFieldState) {
+        snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
+            if (text.isNotEmpty()) {
+                onGetEblanApplicationInfosByLabel(text.toString())
+
+                onShowPopupApplicationMenu(false)
+            }
+        }.collect()
+    }
+
+    LaunchedEffect(key1 = swipeY) {
+        if (swipeY.roundToInt() >= screenHeight &&
+            textFieldState.text.isNotEmpty() &&
+            appDrawerSettings.resetState
+        ) {
+            onGetEblanApplicationInfosByLabel("")
+
+            textFieldState.clearText()
+
+            onUpdateSelectedEblanApplicationInfoTagId(null)
+
+            onScrollItem(0)
+        }
+
+        if (swipeY.roundToInt() > 0 && showPopupApplicationMenu) {
+            onShowPopupApplicationMenu(false)
+        }
+    }
+
+    LaunchedEffect(key1 = Unit) {
+        snapshotFlow { selectedEblanApplicationInfoTagId }.filterNotNull()
+            .onEach { selectedEblanApplicationInfoTag ->
+                onGetEblanApplicationInfosByTagId(selectedEblanApplicationInfoTag)
+            }.collect()
+    }
+
+    LaunchedEffect(key1 = isPressHome) {
+        if (isPressHome) {
+            onShowPopupApplicationMenu(false)
+
+            searchBarState.animateToCollapsed()
+
+            onScrollItem(0)
+
+            onDismiss()
+        }
+    }
+
+    LaunchedEffect(key1 = drag) {
+        if (drag == Drag.Start && searchBarState.currentValue == SearchBarValue.Expanded) {
+            searchBarState.animateToCollapsed()
+        }
+    }
+
+    LaunchedEffect(key1 = horizontalPagerState.isScrollInProgress) {
+        if (horizontalPagerState.isScrollInProgress && showPopupApplicationMenu) {
+            onShowPopupApplicationMenu(false)
+        }
+    }
+
+    BackHandler(enabled = swipeY < screenHeight.toFloat()) {
+        scope.launch {
+            if (appDrawerSettings.resetState) {
+                onScrollItem(0)
+            }
+
+            onShowPopupApplicationMenu(false)
+
+            onDismiss()
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -725,10 +725,8 @@ internal fun ApplicationScreenEffect(
     onGetEblanApplicationInfosByTagId: (Long?) -> Unit,
     onShowPopupApplicationMenu: (Boolean) -> Unit,
     onUpdateSelectedEblanApplicationInfoTagId: (Long?) -> Unit,
-    onScrollItem: suspend (Int) -> Unit = {},
+    onResetScroll: () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
-
     LaunchedEffect(key1 = textFieldState) {
         snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
             if (text.isNotEmpty()) {
@@ -750,7 +748,7 @@ internal fun ApplicationScreenEffect(
 
             onUpdateSelectedEblanApplicationInfoTagId(null)
 
-            onScrollItem(0)
+            onResetScroll()
         }
 
         if (swipeY.roundToInt() > 0 && showPopupApplicationMenu) {
@@ -775,7 +773,7 @@ internal fun ApplicationScreenEffect(
         }
 
         if (isPressHome && appDrawerSettings.resetState) {
-            onScrollItem(0)
+            onResetScroll()
         }
     }
 
@@ -792,14 +790,12 @@ internal fun ApplicationScreenEffect(
     }
 
     BackHandler(enabled = swipeY < screenHeight.toFloat()) {
-        scope.launch {
-            if (appDrawerSettings.resetState) {
-                onScrollItem(0)
-            }
-
-            onShowPopupApplicationMenu(false)
-
-            onDismiss()
+        if (appDrawerSettings.resetState) {
+            onResetScroll()
         }
+
+        onShowPopupApplicationMenu(false)
+
+        onDismiss()
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -19,7 +19,6 @@ package com.eblan.launcher.feature.home.screen.application.horizontal
 
 import android.graphics.Rect
 import android.os.Build
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -35,12 +34,10 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,7 +45,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
@@ -76,6 +72,7 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
 import com.eblan.launcher.feature.home.screen.application.ApplicationInfoPopup
+import com.eblan.launcher.feature.home.screen.application.ApplicationScreenEffect
 import com.eblan.launcher.feature.home.screen.application.ApplicationSearchBarWithoutMenu
 import com.eblan.launcher.feature.home.screen.application.EblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.EblanApplicationInfoTabRow
@@ -87,10 +84,6 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.onEach
-import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -159,10 +152,6 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
         },
     )
 
-    val appDrawerRowsHeight = with(density) {
-        appDrawerSettings.appDrawerRowsHeight.dp.roundToPx()
-    }
-
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -171,63 +160,31 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
 
     var selectedEblanApplicationInfo by remember { mutableStateOf<EblanApplicationInfo?>(null) }
 
-    LaunchedEffect(key1 = textFieldState) {
-        snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
-            horizontalPagerState.scrollToPage(0)
-
-            onGetEblanApplicationInfosByLabel(text.toString())
-
-            showPopupApplicationMenu = false
-        }.collect()
+    val eblanUserPageKeys = remember(key1 = getEblanApplicationInfosByLabel.eblanApplicationInfos) {
+        getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.distinctBy { it.eblanUser.serialNumber }
     }
 
-    LaunchedEffect(key1 = swipeY) {
-        if (swipeY.roundToInt() >= screenHeight && textFieldState.text.isNotEmpty()) {
-            onGetEblanApplicationInfosByLabel("")
-
-            textFieldState.clearText()
-
-            selectedEblanApplicationInfoTagId = null
-        }
-
-        if (swipeY.roundToInt() > 0 && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    LaunchedEffect(key1 = Unit) {
-        snapshotFlow { selectedEblanApplicationInfoTagId }.onEach { selectedEblanApplicationInfoTag ->
-            onGetEblanApplicationInfosByTagId(selectedEblanApplicationInfoTag)
-        }.collect()
-    }
-
-    LaunchedEffect(key1 = isPressHome) {
-        if (isPressHome) {
-            showPopupApplicationMenu = false
-
-            searchBarState.animateToCollapsed()
-
-            onDismiss()
-        }
-    }
-
-    LaunchedEffect(key1 = drag) {
-        if (drag == Drag.Start && searchBarState.currentValue == SearchBarValue.Expanded) {
-            searchBarState.animateToCollapsed()
-        }
-    }
-
-    LaunchedEffect(key1 = horizontalPagerState.isScrollInProgress) {
-        if (horizontalPagerState.isScrollInProgress && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    BackHandler(enabled = swipeY < screenHeight.toFloat()) {
-        showPopupApplicationMenu = false
-
-        onDismiss()
-    }
+    ApplicationScreenEffect(
+        appDrawerSettings = appDrawerSettings,
+        drag = drag,
+        horizontalPagerState = horizontalPagerState,
+        isPressHome = isPressHome,
+        screenHeight = screenHeight,
+        searchBarState = searchBarState,
+        selectedEblanApplicationInfoTagId = selectedEblanApplicationInfoTagId,
+        showPopupApplicationMenu = showPopupApplicationMenu,
+        swipeY = swipeY,
+        textFieldState = textFieldState,
+        onDismiss = onDismiss,
+        onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
+        onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
+        onShowPopupApplicationMenu = { newShowPopupApplicationMenu ->
+            showPopupApplicationMenu = newShowPopupApplicationMenu
+        },
+        onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
+            selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
+        },
+    )
 
     Column(
         modifier = modifier
@@ -255,62 +212,26 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
             }
         }
 
-        if (getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.size > 1) {
+        if (eblanUserPageKeys.size > 1) {
             EblanApplicationInfoTabRow(
                 currentPage = horizontalPagerState.currentPage,
+                eblanUserPageKeys = eblanUserPageKeys,
                 eblanApplicationInfos = getEblanApplicationInfosByLabel.eblanApplicationInfos,
                 onAnimateScrollToPage = horizontalPagerState::animateScrollToPage,
             )
+        }
 
-            HorizontalPager(
-                modifier = Modifier.fillMaxSize(),
-                state = horizontalPagerState,
-            ) { index ->
-                EblanApplicationInfosPage(
-                    appDrawerSettings = appDrawerSettings,
-                    currentPage = currentPage,
-                    drag = drag,
-                    getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
-                    iconPackFilePaths = iconPackFilePaths,
-                    index = index,
-                    managedProfileResult = managedProfileResult,
-                    paddingValues = paddingValues,
-                    isVisibleOverlay = isVisibleOverlay,
-                    onDismiss = onDismiss,
-                    onDragEnd = onDragEnd,
-                    onDraggingGridItem = onDraggingGridItem,
-                    onUpdateGridItemSource = onUpdateGridItemSource,
-                    onUpdateImageBitmap = onUpdateImageBitmap,
-                    onUpdateIsDragging = onUpdateIsDragging,
-                    onUpdateOverlayBounds = { intOffset, intSize ->
-                        onUpdateOverlayBounds(intOffset, intSize)
-
-                        popupIntOffset = intOffset
-
-                        popupIntSize = intSize
-                    },
-                    onUpdatePopupMenu = { newShowPopupApplicationMenu ->
-                        showPopupApplicationMenu = newShowPopupApplicationMenu
-                    },
-                    onUpdatePrivatePopupMenu = { newShowPrivatePopupApplicationMenu ->
-                        showPrivatePopupApplicationMenu = newShowPrivatePopupApplicationMenu
-                    },
-                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                    onVerticalDrag = onVerticalDrag,
-                    onUpdateEblanApplicationInfo = { eblanApplicationInfo ->
-                        selectedEblanApplicationInfo = eblanApplicationInfo
-                    },
-                    onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
-                )
-            }
-        } else {
+        HorizontalPager(
+            modifier = Modifier.fillMaxSize(),
+            state = horizontalPagerState,
+        ) { index ->
             EblanApplicationInfosPage(
                 appDrawerSettings = appDrawerSettings,
                 currentPage = currentPage,
                 drag = drag,
                 getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
                 iconPackFilePaths = iconPackFilePaths,
-                index = 0,
+                index = index,
                 managedProfileResult = managedProfileResult,
                 paddingValues = paddingValues,
                 isVisibleOverlay = isVisibleOverlay,
@@ -325,10 +246,7 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
 
                     popupIntOffset = intOffset
 
-                    popupIntSize = IntSize(
-                        width = intSize.width,
-                        height = appDrawerRowsHeight,
-                    )
+                    popupIntSize = intSize
                 },
                 onUpdatePopupMenu = { newShowPopupApplicationMenu ->
                     showPopupApplicationMenu = newShowPopupApplicationMenu
@@ -342,6 +260,9 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
                     selectedEblanApplicationInfo = eblanApplicationInfo
                 },
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                onScrollToItem = {
+                    horizontalPagerState.scrollToPage(0)
+                },
             )
         }
     }
@@ -462,6 +383,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
     onVerticalDrag: (Float) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
+    onScrollToItem: suspend (Int) -> Unit,
 ) {
     val userManager = LocalUserManager.current
 
@@ -534,6 +456,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
                 onVerticalDrag = onVerticalDrag,
                 onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                onScrollToItem = onScrollToItem,
             )
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() &&
@@ -593,6 +516,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
     onVerticalDrag: (Float) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
+    onScrollToItem: suspend (Int) -> Unit,
 ) {
     HorizontalAppDrawerGridLayout(
         modifier = modifier
@@ -635,6 +559,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         onUpdateSharedElementKey = onUpdateSharedElementKey,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                         onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                        onScrollToItem = onScrollToItem,
                     )
                 }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -184,6 +184,9 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
         onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
             selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
         },
+        onScrollItem = {
+            horizontalPagerState.scrollToPage(0)
+        },
     )
 
     Column(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -84,6 +85,7 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -152,6 +154,8 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
         },
     )
 
+    val scope = rememberCoroutineScope()
+
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -184,8 +188,10 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
         onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
             selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
         },
-        onScrollItem = {
-            horizontalPagerState.scrollToPage(0)
+        onResetScroll = {
+            scope.launch {
+                horizontalPagerState.scrollToPage(0)
+            }
         },
     )
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -19,7 +19,6 @@ package com.eblan.launcher.feature.home.screen.application.list
 
 import android.graphics.Rect
 import android.os.Build
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
@@ -49,12 +48,10 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
@@ -65,7 +62,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -128,11 +124,7 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -204,6 +196,8 @@ internal fun SharedTransitionScope.ListApplicationScreen(
         },
     )
 
+    val scope = rememberCoroutineScope()
+
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -240,7 +234,13 @@ internal fun SharedTransitionScope.ListApplicationScreen(
         onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
             selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
         },
-        onScrollItem = lazyListState::scrollToItem,
+        onResetScroll = {
+            scope.launch {
+                horizontalPagerState.scrollToPage(0)
+
+                lazyListState.scrollToItem(0)
+            }
+        },
     )
 
     Column(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -115,6 +116,7 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
 import com.eblan.launcher.feature.home.screen.application.ApplicationInfoPopup
+import com.eblan.launcher.feature.home.screen.application.ApplicationScreenEffect
 import com.eblan.launcher.feature.home.screen.application.ApplicationSearchBarWithoutMenu
 import com.eblan.launcher.feature.home.screen.application.EblanApplicationInfoTabRow
 import com.eblan.launcher.feature.home.screen.application.PrivateApplicationInfoPopup
@@ -202,10 +204,6 @@ internal fun SharedTransitionScope.ListApplicationScreen(
         },
     )
 
-    val appDrawerRowsHeight = with(density) {
-        appDrawerSettings.appDrawerRowsHeight.dp.roundToPx()
-    }
-
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -216,61 +214,34 @@ internal fun SharedTransitionScope.ListApplicationScreen(
 
     var selectedEblanApplicationInfo by remember { mutableStateOf<EblanApplicationInfo?>(null) }
 
-    LaunchedEffect(key1 = textFieldState) {
-        snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
-            onGetEblanApplicationInfosByLabel(text.toString())
+    val lazyListState = rememberLazyListState()
 
-            showPopupApplicationMenu = false
-        }.collect()
+    val eblanUserPageKeys = remember(key1 = getEblanApplicationInfosByLabel.eblanApplicationInfos) {
+        getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.distinctBy { it.eblanUser.serialNumber }
     }
 
-    LaunchedEffect(key1 = swipeY) {
-        if (swipeY.roundToInt() >= screenHeight && textFieldState.text.isNotEmpty()) {
-            onGetEblanApplicationInfosByLabel("")
-
-            textFieldState.clearText()
-
-            selectedEblanApplicationInfoTagId = null
-        }
-
-        if (swipeY.roundToInt() > 0 && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    LaunchedEffect(key1 = Unit) {
-        snapshotFlow { selectedEblanApplicationInfoTagId }.onEach { selectedEblanApplicationInfoTag ->
-            onGetEblanApplicationInfosByTagId(selectedEblanApplicationInfoTag)
-        }.collect()
-    }
-
-    LaunchedEffect(key1 = isPressHome) {
-        if (isPressHome) {
-            showPopupApplicationMenu = false
-
-            searchBarState.animateToCollapsed()
-
-            onDismiss()
-        }
-    }
-
-    LaunchedEffect(key1 = drag) {
-        if (drag == Drag.Start && searchBarState.currentValue == SearchBarValue.Expanded) {
-            searchBarState.animateToCollapsed()
-        }
-    }
-
-    LaunchedEffect(key1 = horizontalPagerState.isScrollInProgress) {
-        if (horizontalPagerState.isScrollInProgress && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    BackHandler(enabled = swipeY < screenHeight.toFloat()) {
-        showPopupApplicationMenu = false
-
-        onDismiss()
-    }
+    ApplicationScreenEffect(
+        appDrawerSettings = appDrawerSettings,
+        drag = drag,
+        horizontalPagerState = horizontalPagerState,
+        isPressHome = isPressHome,
+        screenHeight = screenHeight,
+        searchBarState = searchBarState,
+        selectedEblanApplicationInfoTagId = selectedEblanApplicationInfoTagId,
+        showPopupApplicationMenu = showPopupApplicationMenu,
+        swipeY = swipeY,
+        textFieldState = textFieldState,
+        onDismiss = onDismiss,
+        onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
+        onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
+        onShowPopupApplicationMenu = { newShowPopupApplicationMenu ->
+            showPopupApplicationMenu = newShowPopupApplicationMenu
+        },
+        onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
+            selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
+        },
+        onScrollItem = lazyListState::scrollToItem,
+    )
 
     Column(
         modifier = modifier
@@ -305,59 +276,16 @@ internal fun SharedTransitionScope.ListApplicationScreen(
         if (getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.size > 1) {
             EblanApplicationInfoTabRow(
                 currentPage = horizontalPagerState.currentPage,
+                eblanUserPageKeys = eblanUserPageKeys,
                 eblanApplicationInfos = getEblanApplicationInfosByLabel.eblanApplicationInfos,
                 onAnimateScrollToPage = horizontalPagerState::animateScrollToPage,
             )
+        }
 
-            HorizontalPager(
-                modifier = Modifier.fillMaxSize(),
-                state = horizontalPagerState,
-            ) { index ->
-                EblanApplicationInfosPage(
-                    appDrawerSettings = appDrawerSettings,
-                    currentPage = currentPage,
-                    drag = drag,
-                    eblanApplicationInfoOrder = appDrawerSettings.eblanApplicationInfoOrder,
-                    getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
-                    iconPackFilePaths = iconPackFilePaths,
-                    index = index,
-                    isRearrangeEblanApplicationInfo = isRearrangeEblanApplicationInfo,
-                    managedProfileResult = managedProfileResult,
-                    paddingValues = paddingValues,
-                    isVisibleOverlay = isVisibleOverlay,
-                    showPopupApplicationMenu = showPopupApplicationMenu,
-                    onDismiss = onDismiss,
-                    onDismissDragAndDrop = {
-                        isRearrangeEblanApplicationInfo = false
-                    },
-                    onDragEnd = onDragEnd,
-                    onDraggingGridItem = onDraggingGridItem,
-                    onUpdateEblanApplicationInfos = onUpdateEblanApplicationInfos,
-                    onUpdateGridItemSource = onUpdateGridItemSource,
-                    onUpdateImageBitmap = onUpdateImageBitmap,
-                    onUpdateIsDragging = onUpdateIsDragging,
-                    onUpdateOverlayBounds = { intOffset, intSize ->
-                        onUpdateOverlayBounds(intOffset, intSize)
-
-                        popupIntOffset = intOffset
-
-                        popupIntSize = intSize
-                    },
-                    onUpdatePopupMenu = { newShowPopupApplicationMenu ->
-                        showPopupApplicationMenu = newShowPopupApplicationMenu
-                    },
-                    onUpdatePrivatePopupMenu = { newShowPrivatePopupApplicationMenu ->
-                        showPrivatePopupApplicationMenu = newShowPrivatePopupApplicationMenu
-                    },
-                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                    onVerticalDrag = onVerticalDrag,
-                    onUpdateEblanApplicationInfo = { eblanApplicationInfo ->
-                        selectedEblanApplicationInfo = eblanApplicationInfo
-                    },
-                    onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
-                )
-            }
-        } else {
+        HorizontalPager(
+            modifier = Modifier.fillMaxSize(),
+            state = horizontalPagerState,
+        ) { index ->
             EblanApplicationInfosPage(
                 appDrawerSettings = appDrawerSettings,
                 currentPage = currentPage,
@@ -365,12 +293,13 @@ internal fun SharedTransitionScope.ListApplicationScreen(
                 eblanApplicationInfoOrder = appDrawerSettings.eblanApplicationInfoOrder,
                 getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
                 iconPackFilePaths = iconPackFilePaths,
-                index = 0,
+                index = index,
                 isRearrangeEblanApplicationInfo = isRearrangeEblanApplicationInfo,
                 managedProfileResult = managedProfileResult,
                 paddingValues = paddingValues,
                 isVisibleOverlay = isVisibleOverlay,
                 showPopupApplicationMenu = showPopupApplicationMenu,
+                lazyListState = lazyListState,
                 onDismiss = onDismiss,
                 onDismissDragAndDrop = {
                     isRearrangeEblanApplicationInfo = false
@@ -386,10 +315,7 @@ internal fun SharedTransitionScope.ListApplicationScreen(
 
                     popupIntOffset = intOffset
 
-                    popupIntSize = IntSize(
-                        width = intSize.width,
-                        height = appDrawerRowsHeight,
-                    )
+                    popupIntSize = intSize
                 },
                 onUpdatePopupMenu = { newShowPopupApplicationMenu ->
                     showPopupApplicationMenu = newShowPopupApplicationMenu
@@ -510,6 +436,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
     paddingValues: PaddingValues,
     showPopupApplicationMenu: Boolean,
     isVisibleOverlay: Boolean,
+    lazyListState: LazyListState,
     onDismiss: () -> Unit,
     onDismissDragAndDrop: () -> Unit,
     onDragEnd: (Float) -> Unit,
@@ -599,6 +526,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
                 paddingValues = paddingValues,
                 showPopupApplicationMenu = showPopupApplicationMenu,
                 isVisibleOverlay = isVisibleOverlay,
+                lazyListState = lazyListState,
                 onDismiss = onDismiss,
                 onDragEnd = onDragEnd,
                 onDraggingGridItem = onDraggingGridItem,
@@ -657,6 +585,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
     paddingValues: PaddingValues,
     isVisibleOverlay: Boolean,
     showPopupApplicationMenu: Boolean,
+    lazyListState: LazyListState,
     onDismiss: () -> Unit,
     onDragEnd: (Float) -> Unit,
     onDraggingGridItem: () -> Unit,
@@ -683,8 +612,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
             onDragEnd = onDragEnd,
         )
     }
-
-    val lazyListState = rememberLazyListState()
 
     val canScroll by remember(key1 = lazyListState) {
         derivedStateOf {
@@ -754,6 +681,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                             onUpdateSharedElementKey = onUpdateSharedElementKey,
                             onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                            onScrollToItem = lazyListState::scrollToItem,
                         )
                     }
 
@@ -798,6 +726,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                             onUpdateSharedElementKey = onUpdateSharedElementKey,
                             onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                            onScrollToItem = lazyListState::scrollToItem,
                         )
                     }
                 }
@@ -841,6 +770,7 @@ private fun SharedTransitionScope.EblanApplicationInfoItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
+    onScrollToItem: suspend (Int) -> Unit,
 ) {
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
@@ -964,6 +894,14 @@ private fun SharedTransitionScope.EblanApplicationInfoItem(
                                 sourceBoundsY + intSize.height,
                             ),
                         )
+
+                        if (appDrawerSettings.resetState) {
+                            scope.launch {
+                                onDismiss()
+
+                                onScrollToItem(0)
+                            }
+                        }
                     },
                     onLongPress = {
                         scope.launch {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -251,7 +251,7 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
             }
         }
 
-        if (getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.size > 1) {
+        if (eblanUserPageKeys.size > 1) {
             EblanApplicationInfoTabRow(
                 currentPage = horizontalPagerState.currentPage,
                 eblanUserPageKeys = eblanUserPageKeys,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -98,6 +98,7 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -168,6 +169,8 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
         },
     )
 
+    val scope = rememberCoroutineScope()
+
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -206,7 +209,13 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
         onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
             selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
         },
-        onScrollItem = lazyGridState::scrollToItem,
+        onResetScroll = {
+            scope.launch {
+                horizontalPagerState.scrollToPage(0)
+
+                lazyGridState.scrollToItem(0)
+            }
+        },
     )
 
     Column(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -19,7 +19,6 @@ package com.eblan.launcher.feature.home.screen.application.vertical
 
 import android.graphics.Rect
 import android.os.Build
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Box
@@ -36,6 +35,7 @@ import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -43,12 +43,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberOverscrollEffect
-import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,7 +56,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
@@ -89,6 +86,7 @@ import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
 import com.eblan.launcher.feature.home.screen.application.ApplicationInfoPopup
+import com.eblan.launcher.feature.home.screen.application.ApplicationScreenEffect
 import com.eblan.launcher.feature.home.screen.application.ApplicationSearchBar
 import com.eblan.launcher.feature.home.screen.application.EblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.EblanApplicationInfoTabRow
@@ -100,10 +98,6 @@ import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.onEach
-import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -174,10 +168,6 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
         },
     )
 
-    val appDrawerRowsHeight = with(density) {
-        appDrawerSettings.appDrawerRowsHeight.dp.roundToPx()
-    }
-
     val searchBarState = rememberSearchBarState()
 
     val textFieldState = rememberTextFieldState()
@@ -190,61 +180,34 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
 
     var selectedEblanApplicationInfo by remember { mutableStateOf<EblanApplicationInfo?>(null) }
 
-    LaunchedEffect(key1 = textFieldState) {
-        snapshotFlow { textFieldState.text }.debounce(500L).onEach { text ->
-            onGetEblanApplicationInfosByLabel(text.toString())
+    val lazyGridState = rememberLazyGridState()
 
-            showPopupApplicationMenu = false
-        }.collect()
+    val eblanUserPageKeys = remember(key1 = getEblanApplicationInfosByLabel.eblanApplicationInfos) {
+        getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.distinctBy { it.eblanUser.serialNumber }
     }
 
-    LaunchedEffect(key1 = swipeY) {
-        if (swipeY.roundToInt() >= screenHeight && textFieldState.text.isNotEmpty()) {
-            onGetEblanApplicationInfosByLabel("")
-
-            textFieldState.clearText()
-
-            selectedEblanApplicationInfoTagId = null
-        }
-
-        if (swipeY.roundToInt() > 0 && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    LaunchedEffect(key1 = Unit) {
-        snapshotFlow { selectedEblanApplicationInfoTagId }.onEach { selectedEblanApplicationInfoTag ->
-            onGetEblanApplicationInfosByTagId(selectedEblanApplicationInfoTag)
-        }.collect()
-    }
-
-    LaunchedEffect(key1 = isPressHome) {
-        if (isPressHome) {
-            showPopupApplicationMenu = false
-
-            searchBarState.animateToCollapsed()
-
-            onDismiss()
-        }
-    }
-
-    LaunchedEffect(key1 = drag) {
-        if (drag == Drag.Start && searchBarState.currentValue == SearchBarValue.Expanded) {
-            searchBarState.animateToCollapsed()
-        }
-    }
-
-    LaunchedEffect(key1 = horizontalPagerState.isScrollInProgress) {
-        if (horizontalPagerState.isScrollInProgress && showPopupApplicationMenu) {
-            showPopupApplicationMenu = false
-        }
-    }
-
-    BackHandler(enabled = swipeY < screenHeight.toFloat()) {
-        showPopupApplicationMenu = false
-
-        onDismiss()
-    }
+    ApplicationScreenEffect(
+        appDrawerSettings = appDrawerSettings,
+        drag = drag,
+        horizontalPagerState = horizontalPagerState,
+        isPressHome = isPressHome,
+        screenHeight = screenHeight,
+        searchBarState = searchBarState,
+        selectedEblanApplicationInfoTagId = selectedEblanApplicationInfoTagId,
+        showPopupApplicationMenu = showPopupApplicationMenu,
+        swipeY = swipeY,
+        textFieldState = textFieldState,
+        onDismiss = onDismiss,
+        onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
+        onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
+        onShowPopupApplicationMenu = { newShowPopupApplicationMenu ->
+            showPopupApplicationMenu = newShowPopupApplicationMenu
+        },
+        onUpdateSelectedEblanApplicationInfoTagId = { newSelectedEblanApplicationInfoTagId ->
+            selectedEblanApplicationInfoTagId = newSelectedEblanApplicationInfoTagId
+        },
+        onScrollItem = lazyGridState::scrollToItem,
+    )
 
     Column(
         modifier = modifier
@@ -282,59 +245,16 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
         if (getEblanApplicationInfosByLabel.eblanApplicationInfos.keys.size > 1) {
             EblanApplicationInfoTabRow(
                 currentPage = horizontalPagerState.currentPage,
+                eblanUserPageKeys = eblanUserPageKeys,
                 eblanApplicationInfos = getEblanApplicationInfosByLabel.eblanApplicationInfos,
                 onAnimateScrollToPage = horizontalPagerState::animateScrollToPage,
             )
+        }
 
-            HorizontalPager(
-                modifier = Modifier.fillMaxSize(),
-                state = horizontalPagerState,
-            ) { index ->
-                EblanApplicationInfosPage(
-                    appDrawerSettings = appDrawerSettings,
-                    currentPage = currentPage,
-                    drag = drag,
-                    eblanApplicationInfoOrder = appDrawerSettings.eblanApplicationInfoOrder,
-                    getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
-                    iconPackFilePaths = iconPackFilePaths,
-                    index = index,
-                    isRearrangeEblanApplicationInfo = isRearrangeEblanApplicationInfo,
-                    managedProfileResult = managedProfileResult,
-                    paddingValues = paddingValues,
-                    isVisibleOverlay = isVisibleOverlay,
-                    showPopupApplicationMenu = showPopupApplicationMenu,
-                    onDismiss = onDismiss,
-                    onDismissDragAndDrop = {
-                        isRearrangeEblanApplicationInfo = false
-                    },
-                    onDragEnd = onDragEnd,
-                    onDraggingGridItem = onDraggingGridItem,
-                    onUpdateEblanApplicationInfos = onUpdateEblanApplicationInfos,
-                    onUpdateGridItemSource = onUpdateGridItemSource,
-                    onUpdateImageBitmap = onUpdateImageBitmap,
-                    onUpdateIsDragging = onUpdateIsDragging,
-                    onUpdateOverlayBounds = { intOffset, intSize ->
-                        onUpdateOverlayBounds(intOffset, intSize)
-
-                        popupIntOffset = intOffset
-
-                        popupIntSize = intSize
-                    },
-                    onUpdatePopupMenu = { newShowPopupApplicationMenu ->
-                        showPopupApplicationMenu = newShowPopupApplicationMenu
-                    },
-                    onUpdatePrivatePopupMenu = { newShowPrivatePopupApplicationMenu ->
-                        showPrivatePopupApplicationMenu = newShowPrivatePopupApplicationMenu
-                    },
-                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                    onVerticalDrag = onVerticalDrag,
-                    onUpdateEblanApplicationInfo = { eblanApplicationInfo ->
-                        selectedEblanApplicationInfo = eblanApplicationInfo
-                    },
-                    onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
-                )
-            }
-        } else {
+        HorizontalPager(
+            modifier = Modifier.fillMaxSize(),
+            state = horizontalPagerState,
+        ) { index ->
             EblanApplicationInfosPage(
                 appDrawerSettings = appDrawerSettings,
                 currentPage = currentPage,
@@ -342,12 +262,13 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
                 eblanApplicationInfoOrder = appDrawerSettings.eblanApplicationInfoOrder,
                 getEblanApplicationInfosByLabel = getEblanApplicationInfosByLabel,
                 iconPackFilePaths = iconPackFilePaths,
-                index = 0,
+                index = index,
                 isRearrangeEblanApplicationInfo = isRearrangeEblanApplicationInfo,
                 managedProfileResult = managedProfileResult,
                 paddingValues = paddingValues,
                 isVisibleOverlay = isVisibleOverlay,
                 showPopupApplicationMenu = showPopupApplicationMenu,
+                lazyGridState = lazyGridState,
                 onDismiss = onDismiss,
                 onDismissDragAndDrop = {
                     isRearrangeEblanApplicationInfo = false
@@ -363,10 +284,7 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
 
                     popupIntOffset = intOffset
 
-                    popupIntSize = IntSize(
-                        width = intSize.width,
-                        height = appDrawerRowsHeight,
-                    )
+                    popupIntSize = intSize
                 },
                 onUpdatePopupMenu = { newShowPopupApplicationMenu ->
                     showPopupApplicationMenu = newShowPopupApplicationMenu
@@ -503,6 +421,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
     paddingValues: PaddingValues,
     showPopupApplicationMenu: Boolean,
     isVisibleOverlay: Boolean,
+    lazyGridState: LazyGridState,
     onDismiss: () -> Unit,
     onDismissDragAndDrop: () -> Unit,
     onDragEnd: (Float) -> Unit,
@@ -592,6 +511,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
                 paddingValues = paddingValues,
                 showPopupApplicationMenu = showPopupApplicationMenu,
                 isVisibleOverlay = isVisibleOverlay,
+                lazyGridState = lazyGridState,
                 onDismiss = onDismiss,
                 onDragEnd = onDragEnd,
                 onDraggingGridItem = onDraggingGridItem,
@@ -605,6 +525,7 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
                 onVerticalDrag = onVerticalDrag,
                 onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                onScrollToItem = lazyGridState::scrollToItem,
             )
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() &&
@@ -650,6 +571,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
     paddingValues: PaddingValues,
     isVisibleOverlay: Boolean,
     showPopupApplicationMenu: Boolean,
+    lazyGridState: LazyGridState,
     onDismiss: () -> Unit,
     onDragEnd: (Float) -> Unit,
     onDraggingGridItem: () -> Unit,
@@ -666,6 +588,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
     onVerticalDrag: (Float) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
+    onScrollToItem: suspend (Int) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
 
@@ -676,8 +599,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
             onDragEnd = onDragEnd,
         )
     }
-
-    val lazyGridState = rememberLazyGridState()
 
     val canScroll by remember(key1 = lazyGridState) {
         derivedStateOf {
@@ -749,6 +670,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                             onUpdateSharedElementKey = onUpdateSharedElementKey,
                             onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                            onScrollToItem = onScrollToItem,
                         )
                     }
 
@@ -794,6 +716,7 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                             onUpdateSharedElementKey = onUpdateSharedElementKey,
                             onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
+                            onScrollToItem = onScrollToItem,
                         )
                     }
                 }

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -208,6 +208,17 @@ private fun Success(
 
             HorizontalDivider(modifier = Modifier.fillMaxWidth())
 
+            SettingsSwitch(
+                checked = appDrawerSettings.resetState,
+                title = "Reset State",
+                subtitle = "Reset app drawer state when not visible",
+                onCheckedChange = { newResetState ->
+                    onUpdateAppDrawerSettings(appDrawerSettings.copy(resetState = newResetState))
+                },
+            )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
             SettingsColumn(
                 title = "Hidden Applications",
                 subtitle = "Hidden Applications",


### PR DESCRIPTION
Closes #736 

- Centralized `LaunchedEffect` and `BackHandler` logic into a new shared `ApplicationScreenEffect` composable across `ListApplicationScreen`, `VerticalApplicationScreen`, and `HorizontalApplicationScreen`.
- Added a `resetState` field to `AppDrawerSettings` and the underlying Proto definition to allow users to toggle whether the app drawer resets its scroll position and search state when dismissed.
- Implemented state resetting logic that clears search text and scrolls the application list back to the top when `resetState` is enabled.
- Updated `EblanApplicationInfoTabRow` to accept pre-calculated `eblanUserPageKeys` to improve performance and consistency.
- Added a "Reset State" switch to the App Drawer settings screen.
- Fixed a bug where `popupIntSize` in `ListApplicationScreen` was incorrectly using a fixed row height instead of the actual item size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Reset State" toggle in App Drawer settings to control automatic reset behavior.
  * When enabled, selecting an app, swiping down, or pressing Home clears searches/filters and scrolls the app drawer to the top.

* **Refactor**
  * Centralized UI side-effect handling for consistent search, tag, popup and scroll behaviors across list, grid and pager layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->