### PR TITLE
Implemented support for excluding tagged applications from the main app drawer

### DIFF
--- a/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
+++ b/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
@@ -18,4 +18,5 @@ message AppDrawerSettingsProto {
   AppDrawerTypeProto AppDrawerTypeProto = 8;
   int32 horizontalAppDrawerColumns = 9;
   int32 horizontalAppDrawerRows = 10;
+  bool excludeTaggedApps = 11;
 }

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
@@ -88,6 +88,7 @@ class UserDataSerializer @Inject constructor() : Serializer<UserDataProto> {
         appDrawerTypeProto = AppDrawerTypeProto.Vertical
         horizontalAppDrawerColumns = 5
         horizontalAppDrawerRows = 5
+        excludeTaggedApps = false
     }.build()
 
     private val defaultGestureSettingsProto = GestureSettingsProto.newBuilder().apply {

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -74,6 +74,7 @@ internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = A
     appDrawerType = appDrawerTypeProto.toAppDrawerType(),
     horizontalAppDrawerColumns = horizontalAppDrawerColumns,
     horizontalAppDrawerRows = horizontalAppDrawerRows,
+    excludeTaggedApps = excludeTaggedApps,
 )
 
 internal fun GridItemSettingsProto.toGridItemSettings(): GridItemSettings = GridItemSettings(
@@ -121,6 +122,7 @@ internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProt
     .setAppDrawerTypeProto(appDrawerType.toAppDrawerTypeProto())
     .setHorizontalAppDrawerColumns(horizontalAppDrawerColumns)
     .setHorizontalAppDrawerRows(horizontalAppDrawerRows)
+    .setExcludeTaggedApps(excludeTaggedApps)
     .build()
 
 internal fun GeneralSettings.toGeneralSettingsProto(): GeneralSettingsProto = GeneralSettingsProto.newBuilder().setThemeProto(theme.toThemeProto())

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
@@ -144,6 +144,13 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
         }
     }
 
+    override fun getEblanApplicationInfosWithoutTag(): Flow<List<EblanApplicationInfo>> = eblanApplicationInfoDao.getEblanApplicationInfoEntitiesWithoutTags()
+        .map { entities ->
+            entities.map { entity ->
+                entity.asModel()
+            }
+        }
+
     private fun EblanApplicationInfoTagEntity.asModel(): EblanApplicationInfoTag = EblanApplicationInfoTag(
         id = id,
         name = name,

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoDao.kt
@@ -98,4 +98,18 @@ interface EblanApplicationInfoDao {
         serialNumber: Long,
         componentName: String,
     ): Flow<List<EblanApplicationInfoTagEntity>>
+
+    @Query(
+        """
+    SELECT app.*
+    FROM EblanApplicationInfoEntity AS app
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM EblanApplicationInfoTagCrossRefEntity AS ref
+        WHERE ref.componentName = app.componentName
+          AND ref.serialNumber = app.serialNumber
+    )
+    """,
+    )
+    fun getEblanApplicationInfoEntitiesWithoutTags(): Flow<List<EblanApplicationInfoEntity>>
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
@@ -27,4 +27,5 @@ data class AppDrawerSettings(
     val appDrawerType: AppDrawerType,
     val horizontalAppDrawerColumns: Int,
     val horizontalAppDrawerRows: Int,
+    val excludeTaggedApps: Boolean,
 )

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/EblanApplicationInfoRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/EblanApplicationInfoRepository.kt
@@ -63,4 +63,6 @@ interface EblanApplicationInfoRepository {
         serialNumber: Long,
         componentName: String,
     ): Flow<List<EblanApplicationInfoTag>>
+
+    fun getEblanApplicationInfosWithoutTag(): Flow<List<EblanApplicationInfo>>
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
-import kotlin.collections.toSortedMap
 
 class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
     private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
@@ -48,13 +47,21 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         labelFlow: Flow<String>,
         eblanApplicationInfoTagIdFlow: Flow<Long?>,
     ): Flow<GetEblanApplicationInfosByLabelAndTag> {
-        val eblanApplicationInfosFlow = eblanApplicationInfoTagIdFlow.flatMapLatest { id ->
-            if (id != null) {
-                eblanApplicationInfoRepository.getEblanApplicationInfosByTagId(id = id)
-            } else {
-                eblanApplicationInfoRepository.eblanApplicationInfos
+        val eblanApplicationInfosFlow =
+            combine(
+                eblanApplicationInfoTagIdFlow,
+                userDataRepository.userData,
+            ) { tagId, userData ->
+                tagId to userData.appDrawerSettings.excludeTaggedApps
+            }.flatMapLatest { (tagId, excludeTaggedApps) ->
+                if (tagId != null) {
+                    eblanApplicationInfoRepository.getEblanApplicationInfosByTagId(tagId)
+                } else if (excludeTaggedApps) {
+                    eblanApplicationInfoRepository.getEblanApplicationInfosWithoutTag()
+                } else {
+                    eblanApplicationInfoRepository.eblanApplicationInfos
+                }
             }
-        }
 
         return combine(
             userDataRepository.userData,

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -53,6 +53,7 @@ import com.eblan.launcher.ui.dialog.TextColorDialog
 import com.eblan.launcher.ui.dialog.TwoTextFieldsDialog
 import com.eblan.launcher.ui.settings.GridItemSettings
 import com.eblan.launcher.ui.settings.SettingsColumn
+import com.eblan.launcher.ui.settings.SettingsSwitch
 import com.eblan.launcher.ui.settings.TextColorSettingsRow
 
 @Composable
@@ -201,6 +202,17 @@ private fun Success(
                 subtitle = "Hidden Applications",
                 onClick = {
                     showHiddenEblanApplicationInfosDialog = true
+                },
+            )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
+            SettingsSwitch(
+                checked = appDrawerSettings.excludeTaggedApps,
+                title = "Exclude Tagged apps",
+                subtitle = "Exclude tagged apps",
+                onCheckedChange = { excludeTaggedApps ->
+                    onUpdateAppDrawerSettings(appDrawerSettings.copy(excludeTaggedApps = excludeTaggedApps))
                 },
             )
         }


### PR DESCRIPTION
Closes #753

- Added `excludeTaggedApps` flag to `AppDrawerSettings` and persisted it via DataStore and Protobuf.
- Introduced `getEblanApplicationInfoEntitiesWithoutTags` in `EblanApplicationInfoDao` to query applications that do not have any associated tags.
- Updated `EblanApplicationInfoRepository` and its implementation to support fetching untagged applications.
- Modified `GetEblanApplicationInfosByLabelAndTagUseCase` to filter out tagged apps when no specific tag is selected and the `excludeTaggedApps` setting is enabled.
- Added a toggle for "Exclude Tagged apps" in the `AppDrawerSettingsScreen`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Exclude Tagged Apps" toggle in the App Drawer settings screen, allowing users to hide tagged applications from the app drawer when enabled.

* **Chores**
  * Extended app drawer settings configuration and data layer to support the new exclude tagged apps feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->