### PR TITLE
Refactored and centralized launcher utility logic

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/IconPackInfoUseCaseUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/IconPackInfoUseCaseUtil.kt
@@ -20,79 +20,82 @@ package com.eblan.launcher.domain.usecase.iconpack
 import com.eblan.launcher.domain.common.IconKeyGenerator
 import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.IconPackManager
-import com.eblan.launcher.domain.model.FastLauncherAppsActivityInfo
+import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.IconPackInfoComponent
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import java.io.File
+import javax.inject.Inject
 
-internal suspend fun updateIconPackInfos(
-    iconPackInfoPackageName: String,
-    fileManager: FileManager,
-    iconPackManager: IconPackManager,
-    fastLauncherAppsActivityInfos: List<FastLauncherAppsActivityInfo>,
-    iconKeyGenerator: IconKeyGenerator,
+class IconPackInfoUseCaseUtil @Inject internal constructor(
+    private val fileManager: FileManager,
+    private val iconPackManager: IconPackManager,
+    private val iconKeyGenerator: IconKeyGenerator,
+    private val launcherAppsWrapper: LauncherAppsWrapper,
 ) {
-    if (iconPackInfoPackageName.isEmpty()) return
+    suspend fun updateIconPackInfos(iconPackInfoPackageName: String) {
+        if (iconPackInfoPackageName.isEmpty()) return
 
-    val iconPackInfoDirectory = File(
-        fileManager.getFilesDirectory(name = FileManager.ICON_PACKS_DIR),
-        iconPackInfoPackageName,
-    ).apply { if (!exists()) mkdirs() }
+        val fastLauncherAppsActivityInfos = launcherAppsWrapper.getFastActivityList()
 
-    val appFilter = iconPackManager.getIconPackInfoComponents(packageName = iconPackInfoPackageName)
+        val iconPackInfoDirectory = File(
+            fileManager.getFilesDirectory(name = FileManager.ICON_PACKS_DIR),
+            iconPackInfoPackageName,
+        ).apply { if (!exists()) mkdirs() }
 
-    val installedComponentHashCodes = buildSet {
-        fastLauncherAppsActivityInfos.forEach { fastLauncherAppsActivityInfo ->
-            currentCoroutineContext().ensureActive()
+        val appFilter =
+            iconPackManager.getIconPackInfoComponents(packageName = iconPackInfoPackageName)
 
-            val file = File(
-                iconPackInfoDirectory,
-                iconKeyGenerator.getHashedName(name = fastLauncherAppsActivityInfo.componentName),
-            )
+        val installedComponentHashCodes = buildSet {
+            fastLauncherAppsActivityInfos.forEach { fastLauncherAppsActivityInfo ->
+                currentCoroutineContext().ensureActive()
 
-            cacheIconPackFile(
-                iconPackManager = iconPackManager,
-                appFilter = appFilter,
-                iconPackInfoPackageName = iconPackInfoPackageName,
-                file = file,
-                componentName = fastLauncherAppsActivityInfo.componentName,
-            )
+                val file = File(
+                    iconPackInfoDirectory,
+                    iconKeyGenerator.getHashedName(name = fastLauncherAppsActivityInfo.componentName),
+                )
 
-            add(iconKeyGenerator.getHashedName(name = fastLauncherAppsActivityInfo.componentName))
+                cacheIconPackFile(
+                    appFilter = appFilter,
+                    iconPackInfoPackageName = iconPackInfoPackageName,
+                    file = file,
+                    componentName = fastLauncherAppsActivityInfo.componentName,
+                )
+
+                add(iconKeyGenerator.getHashedName(name = fastLauncherAppsActivityInfo.componentName))
+            }
         }
+
+        iconPackInfoDirectory.listFiles()
+            ?.filter {
+                currentCoroutineContext().ensureActive()
+
+                it.isFile && it.name !in installedComponentHashCodes
+            }
+            ?.forEach {
+                currentCoroutineContext().ensureActive()
+
+                it.delete()
+            }
     }
 
-    iconPackInfoDirectory.listFiles()
-        ?.filter {
+    suspend fun cacheIconPackFile(
+        appFilter: List<IconPackInfoComponent>,
+        iconPackInfoPackageName: String,
+        file: File,
+        componentName: String,
+    ) {
+        appFilter.find { iconPackInfoComponent ->
             currentCoroutineContext().ensureActive()
 
-            it.isFile && it.name !in installedComponentHashCodes
+            componentName == iconPackInfoComponent.componentName.removePrefix("ComponentInfo{")
+                .removeSuffix("}")
+        }?.let { iconPackInfoComponent ->
+            iconPackManager.createIconPackInfoPath(
+                packageName = iconPackInfoPackageName,
+                drawableName = iconPackInfoComponent.drawableName,
+                file = file,
+            )
         }
-        ?.forEach {
-            currentCoroutineContext().ensureActive()
-
-            it.delete()
-        }
-}
-
-internal suspend fun cacheIconPackFile(
-    iconPackManager: IconPackManager,
-    appFilter: List<IconPackInfoComponent>,
-    iconPackInfoPackageName: String,
-    file: File,
-    componentName: String,
-) {
-    appFilter.find { iconPackInfoComponent ->
-        currentCoroutineContext().ensureActive()
-
-        componentName == iconPackInfoComponent.componentName.removePrefix("ComponentInfo{")
-            .removeSuffix("}")
-    }?.let { iconPackInfoComponent ->
-        iconPackManager.createIconPackInfoPath(
-            packageName = iconPackInfoPackageName,
-            drawableName = iconPackInfoComponent.drawableName,
-            file = file,
-        )
     }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/iconpack/UpdateIconPackInfosUseCase.kt
@@ -19,10 +19,6 @@ package com.eblan.launcher.domain.usecase.iconpack
 
 import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
-import com.eblan.launcher.domain.common.IconKeyGenerator
-import com.eblan.launcher.domain.framework.FileManager
-import com.eblan.launcher.domain.framework.IconPackManager
-import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.EblanIconPackInfo
 import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.EblanIconPackInfoRepository
@@ -31,12 +27,9 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class UpdateIconPackInfosUseCase @Inject constructor(
-    private val launcherAppsWrapper: LauncherAppsWrapper,
-    private val iconPackManager: IconPackManager,
-    private val fileManager: FileManager,
     private val eblanIconPackInfoRepository: EblanIconPackInfoRepository,
     private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
-    private val iconKeyGenerator: IconKeyGenerator,
+    private val iconPackInfoUseCaseUtil: IconPackInfoUseCaseUtil,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(iconPackInfoPackageName: String) {
@@ -48,13 +41,7 @@ class UpdateIconPackInfosUseCase @Inject constructor(
                 ).firstOrNull()
 
             if (eblanApplicationInfo != null) {
-                updateIconPackInfos(
-                    iconPackInfoPackageName = iconPackInfoPackageName,
-                    fileManager = fileManager,
-                    iconPackManager = iconPackManager,
-                    fastLauncherAppsActivityInfos = launcherAppsWrapper.getFastActivityList(),
-                    iconKeyGenerator = iconKeyGenerator,
-                )
+                iconPackInfoUseCaseUtil.updateIconPackInfos(iconPackInfoPackageName = iconPackInfoPackageName)
 
                 eblanIconPackInfoRepository.upsertEblanIconPackInfo(
                     eblanIconPackInfo = EblanIconPackInfo(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
@@ -24,7 +24,6 @@ import com.eblan.launcher.domain.framework.AppWidgetManagerWrapper
 import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.IconPackManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
-import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.model.ApplicationInfoGridItem
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.HomeSettings
@@ -37,7 +36,7 @@ import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
 import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsUseCase
-import com.eblan.launcher.domain.usecase.iconpack.cacheIconPackFile
+import com.eblan.launcher.domain.usecase.iconpack.IconPackInfoUseCaseUtil
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -49,7 +48,6 @@ import kotlin.uuid.ExperimentalUuidApi
 
 class AddPackageUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
-    private val packageManagerWrapper: PackageManagerWrapper,
     private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
     private val appWidgetManagerWrapper: AppWidgetManagerWrapper,
     private val eblanAppWidgetProviderInfoRepository: EblanAppWidgetProviderInfoRepository,
@@ -62,6 +60,8 @@ class AddPackageUseCase @Inject constructor(
     private val gridRepository: GridRepository,
     private val getFolderGridItemsUseCase: GetFolderGridItemsUseCase,
     private val applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
+    private val iconPackInfoUseCaseUtil: IconPackInfoUseCaseUtil,
+    private val launcherAppsUtil: LauncherAppsUtil,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -147,9 +147,10 @@ class AddPackageUseCase @Inject constructor(
 
         if (!homeSettings.addNewAppsToHomeScreen) return
 
-        val gridItems = (gridRepository.gridItems.first() + getFolderGridItemsUseCase().first()).toMutableList()
+        val gridItems =
+            (gridRepository.gridItems.first() + getFolderGridItemsUseCase().first()).toMutableList()
 
-        addNewApplicationToHomeScreen(
+        launcherAppsUtil.addNewApplicationToHomeScreen(
             gridItems = gridItems,
             componentName = componentName,
             packageName = packageName,
@@ -171,10 +172,8 @@ class AddPackageUseCase @Inject constructor(
             }.map { appWidgetManagerAppWidgetProviderInfo ->
                 currentCoroutineContext().ensureActive()
 
-                appWidgetManagerAppWidgetProviderInfo.toEblanAppWidgetProviderInfo(
-                    fileManager = fileManager,
-                    packageManagerWrapper = packageManagerWrapper,
-                    iconKeyGenerator = iconKeyGenerator,
+                launcherAppsUtil.toEblanAppWidgetProviderInfo(
+                    appWidgetManagerAppWidgetProviderInfo = appWidgetManagerAppWidgetProviderInfo,
                 )
             }
 
@@ -194,7 +193,7 @@ class AddPackageUseCase @Inject constructor(
             )?.map { launcherAppsShortcutInfo ->
                 currentCoroutineContext().ensureActive()
 
-                launcherAppsShortcutInfo.toEblanShortcutInfo()
+                launcherAppsUtil.toEblanShortcutInfo(launcherAppsShortcutInfo = launcherAppsShortcutInfo)
             }
 
         if (eblanShortcutInfos != null) {
@@ -214,11 +213,7 @@ class AddPackageUseCase @Inject constructor(
         ).map { shortcutConfigActivityInfo ->
             currentCoroutineContext().ensureActive()
 
-            shortcutConfigActivityInfo.toEblanShortcutConfig(
-                fileManager = fileManager,
-                packageManagerWrapper = packageManagerWrapper,
-                iconKeyGenerator = iconKeyGenerator,
-            )
+            launcherAppsUtil.toEblanShortcutConfig(shortcutConfigActivityInfo = shortcutConfigActivityInfo)
         }
 
         eblanShortcutConfigRepository.upsertEblanShortcutConfigs(
@@ -248,8 +243,7 @@ class AddPackageUseCase @Inject constructor(
                 iconKeyGenerator.getHashedName(name = launcherAppsActivityInfo.componentName),
             )
 
-            cacheIconPackFile(
-                iconPackManager = iconPackManager,
+            iconPackInfoUseCaseUtil.cacheIconPackFile(
                 appFilter = appFilter,
                 iconPackInfoPackageName = iconPackInfoPackageName,
                 file = file,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangePackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangePackageUseCase.kt
@@ -27,16 +27,12 @@ import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.model.EblanShortcutConfig
 import com.eblan.launcher.domain.model.FastLauncherAppsActivityInfo
-import com.eblan.launcher.domain.repository.ApplicationInfoGridItemRepository
 import com.eblan.launcher.domain.repository.EblanAppWidgetProviderInfoRepository
 import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
-import com.eblan.launcher.domain.repository.ShortcutConfigGridItemRepository
-import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.repository.WidgetGridItemRepository
-import com.eblan.launcher.domain.usecase.iconpack.cacheIconPackFile
+import com.eblan.launcher.domain.usecase.iconpack.IconPackInfoUseCaseUtil
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -49,18 +45,16 @@ class ChangePackageUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
     private val packageManagerWrapper: PackageManagerWrapper,
     private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
-    private val applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
     private val launcherAppsWrapper: LauncherAppsWrapper,
     private val eblanAppWidgetProviderInfoRepository: EblanAppWidgetProviderInfoRepository,
     private val appWidgetManagerWrapper: AppWidgetManagerWrapper,
     private val eblanShortcutInfoRepository: EblanShortcutInfoRepository,
-    private val shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
-    private val shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
     private val eblanShortcutConfigRepository: EblanShortcutConfigRepository,
     private val fileManager: FileManager,
     private val iconPackManager: IconPackManager,
-    private val widgetGridItemRepository: WidgetGridItemRepository,
     private val iconKeyGenerator: IconKeyGenerator,
+    private val iconPackInfoUseCaseUtil: IconPackInfoUseCaseUtil,
+    private val launcherAppsUtil: LauncherAppsUtil,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -110,7 +104,7 @@ class ChangePackageUseCase @Inject constructor(
                 serialNumber = serialNumber,
                 packageName = packageName,
             ).map { eblanApplicationInfo ->
-                eblanApplicationInfo.toSyncEblanApplicationInfo()
+                launcherAppsUtil.toSyncEblanApplicationInfo(eblanApplicationInfo = eblanApplicationInfo)
             }
 
         val newSyncEblanApplicationInfosByPackageName = buildList {
@@ -124,27 +118,23 @@ class ChangePackageUseCase @Inject constructor(
                     ).map { shortcutConfigActivityInfo ->
                         currentCoroutineContext().ensureActive()
 
-                        shortcutConfigActivityInfo.toEblanShortcutConfig(
-                            fileManager = fileManager,
-                            packageManagerWrapper = packageManagerWrapper,
-                            iconKeyGenerator = iconKeyGenerator,
-                        )
+                        launcherAppsUtil.toEblanShortcutConfig(shortcutConfigActivityInfo = shortcutConfigActivityInfo)
                     },
                 )
 
-                add(launcherAppsActivityInfo.toSyncEblanApplicationInfo())
+                add(launcherAppsUtil.toSyncEblanApplicationInfo(launcherAppsActivityInfo = launcherAppsActivityInfo))
             }
         }
 
         if (oldSyncEblanApplicationInfosByPackageName.toSet() != newSyncEblanApplicationInfosByPackageName.toSet()) {
             val newDeleteEblanApplicationInfos =
                 newSyncEblanApplicationInfosByPackageName.map { syncEblanApplicationInfo ->
-                    syncEblanApplicationInfo.toDeleteEblanApplicationInfo()
+                    launcherAppsUtil.toDeleteEblanApplicationInfo(syncEblanApplicationInfo = syncEblanApplicationInfo)
                 }.toSet()
 
             val oldDeleteEblanApplicationInfos =
                 oldSyncEblanApplicationInfosByPackageName.map { syncEblanApplicationInfo ->
-                    syncEblanApplicationInfo.toDeleteEblanApplicationInfo()
+                    launcherAppsUtil.toDeleteEblanApplicationInfo(syncEblanApplicationInfo = syncEblanApplicationInfo)
                 }
                     .filter { deleteEblanApplicationInfo -> deleteEblanApplicationInfo !in newDeleteEblanApplicationInfos }
 
@@ -156,17 +146,10 @@ class ChangePackageUseCase @Inject constructor(
                 deleteEblanApplicationInfos = oldDeleteEblanApplicationInfos,
             )
 
-            deleteEblanApplicationInfoIcons(
-                eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-                eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
-                oldDeleteEblanApplicationInfos = oldDeleteEblanApplicationInfos,
-            )
+            launcherAppsUtil.deleteEblanApplicationInfoIcons(oldDeleteEblanApplicationInfos = oldDeleteEblanApplicationInfos)
         }
 
-        updateApplicationInfoGridItems(
-            eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-            applicationInfoGridItemRepository = applicationInfoGridItemRepository,
-        )
+        launcherAppsUtil.updateApplicationInfoGridItems()
 
         updateEblanShortcutConfigs(
             serialNumber = serialNumber,
@@ -197,22 +180,18 @@ class ChangePackageUseCase @Inject constructor(
             appWidgetManagerAppWidgetProviderInfosByPackageName.map { appWidgetManagerAppWidgetProviderInfo ->
                 currentCoroutineContext().ensureActive()
 
-                appWidgetManagerAppWidgetProviderInfo.toEblanAppWidgetProviderInfo(
-                    fileManager = fileManager,
-                    packageManagerWrapper = packageManagerWrapper,
-                    iconKeyGenerator = iconKeyGenerator,
-                )
+                launcherAppsUtil.toEblanAppWidgetProviderInfo(appWidgetManagerAppWidgetProviderInfo = appWidgetManagerAppWidgetProviderInfo)
             }
 
         if (oldEblanAppWidgetProviderInfosByPackageName.toSet() != newEblanAppWidgetProviderInfosByPackageName.toSet()) {
             val newDeleteEblanAppWidgetProviderInfos =
                 newEblanAppWidgetProviderInfosByPackageName.map { eblanAppWidgetProviderInfo ->
-                    eblanAppWidgetProviderInfo.toDeleteEblanAppWidgetProviderInfo()
+                    launcherAppsUtil.toDeleteEblanAppWidgetProviderInfo(eblanAppWidgetProviderInfo = eblanAppWidgetProviderInfo)
                 }.toSet()
 
             val oldDeleteEblanAppWidgetProviderInfos =
                 oldEblanAppWidgetProviderInfosByPackageName.map { eblanAppWidgetProviderInfo ->
-                    eblanAppWidgetProviderInfo.toDeleteEblanAppWidgetProviderInfo()
+                    launcherAppsUtil.toDeleteEblanAppWidgetProviderInfo(eblanAppWidgetProviderInfo = eblanAppWidgetProviderInfo)
                 }.filter { deleteEblanAppWidgetProviderInfo ->
                     deleteEblanAppWidgetProviderInfo !in newDeleteEblanAppWidgetProviderInfos
                 }
@@ -225,19 +204,11 @@ class ChangePackageUseCase @Inject constructor(
                 deleteEblanAppWidgetProviderInfos = oldDeleteEblanAppWidgetProviderInfos,
             )
 
-            deleteEblanAppWidgetProviderInfoIcons(
-                eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-                eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
+            launcherAppsUtil.deleteEblanAppWidgetProviderInfoIcons(
                 oldDeleteEblanAppWidgetProviderInfos = oldDeleteEblanAppWidgetProviderInfos,
             )
 
-            updateWidgetGridItems(
-                eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
-                fileManager = fileManager,
-                packageManagerWrapper = packageManagerWrapper,
-                widgetGridItemRepository = widgetGridItemRepository,
-                iconKeyGenerator = iconKeyGenerator,
-            )
+            launcherAppsUtil.updateWidgetGridItems()
         }
     }
 
@@ -262,18 +233,18 @@ class ChangePackageUseCase @Inject constructor(
             launcherAppsShortcutInfosByPackageName.map { launcherAppsShortcutInfo ->
                 currentCoroutineContext().ensureActive()
 
-                launcherAppsShortcutInfo.toEblanShortcutInfo()
+                launcherAppsUtil.toEblanShortcutInfo(launcherAppsShortcutInfo = launcherAppsShortcutInfo)
             }
 
         if (oldEblanShortcutInfosByPackageName.toSet() != newEblanShortcutInfosByPackageName.toSet()) {
             val newDeleteEblanShortcutInfos =
                 newEblanShortcutInfosByPackageName.map { eblanShortcutInfo ->
-                    eblanShortcutInfo.toDeleteEblanShortcutInfo()
+                    launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
                 }.toSet()
 
             val oldDeleteEblanShortcutInfos =
                 oldEblanShortcutInfosByPackageName.map { eblanShortcutInfo ->
-                    eblanShortcutInfo.toDeleteEblanShortcutInfo()
+                    launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
                 }.filter { deleteEblanShortcutInfo ->
                     deleteEblanShortcutInfo !in newDeleteEblanShortcutInfos
                 }
@@ -286,15 +257,9 @@ class ChangePackageUseCase @Inject constructor(
                 deleteEblanShortcutInfos = oldDeleteEblanShortcutInfos,
             )
 
-            deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
+            launcherAppsUtil.deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
 
-            updateShortcutInfoGridItems(
-                eblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos(),
-                shortcutInfoGridItemRepository = shortcutInfoGridItemRepository,
-                fileManager = fileManager,
-                packageManagerWrapper = packageManagerWrapper,
-                iconKeyGenerator = iconKeyGenerator,
-            )
+            launcherAppsUtil.updateShortcutInfoGridItems()
         }
     }
 
@@ -311,12 +276,12 @@ class ChangePackageUseCase @Inject constructor(
 
         if (oldEblanShortcutConfigsByPackageName.toSet() != newEblanShortcutConfigs.toSet()) {
             val newDeleteEblanShortcutConfigs = newEblanShortcutConfigs.map { eblanShortcutConfig ->
-                eblanShortcutConfig.toDeleteEblanShortcutConfig()
+                launcherAppsUtil.toDeleteEblanShortcutConfig(eblanShortcutConfig = eblanShortcutConfig)
             }.toSet()
 
             val oldDeleteEblanShortcutConfigs =
                 oldEblanShortcutConfigsByPackageName.map { eblanShortcutConfig ->
-                    eblanShortcutConfig.toDeleteEblanShortcutConfig()
+                    launcherAppsUtil.toDeleteEblanShortcutConfig(eblanShortcutConfig = eblanShortcutConfig)
                 }.filter { deleteEblanShortcutConfig ->
                     deleteEblanShortcutConfig !in newDeleteEblanShortcutConfigs
                 }
@@ -329,15 +294,9 @@ class ChangePackageUseCase @Inject constructor(
                 deleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs,
             )
 
-            deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs)
+            launcherAppsUtil.deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs)
 
-            updateShortcutConfigGridItems(
-                eblanShortcutConfigs = eblanShortcutConfigRepository.getEblanShortcutConfigs(),
-                shortcutConfigGridItemRepository = shortcutConfigGridItemRepository,
-                fileManager = fileManager,
-                packageManagerWrapper = packageManagerWrapper,
-                iconKeyGenerator = iconKeyGenerator,
-            )
+            launcherAppsUtil.updateShortcutConfigGridItems()
         }
     }
 
@@ -385,8 +344,7 @@ class ChangePackageUseCase @Inject constructor(
                     iconKeyGenerator.getHashedName(name = fastLauncherAppsActivityInfo.componentName),
                 )
 
-                cacheIconPackFile(
-                    iconPackManager = iconPackManager,
+                iconPackInfoUseCaseUtil.cacheIconPackFile(
                     appFilter = appFilter,
                     iconPackInfoPackageName = iconPackInfoPackageName,
                     file = file,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangeShortcutsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangeShortcutsUseCase.kt
@@ -19,13 +19,9 @@ package com.eblan.launcher.domain.usecase.launcherapps
 
 import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
-import com.eblan.launcher.domain.common.IconKeyGenerator
-import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
-import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.model.LauncherAppsShortcutInfo
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
-import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ensureActive
@@ -37,10 +33,7 @@ class ChangeShortcutsUseCase @Inject constructor(
     private val eblanShortcutInfoRepository: EblanShortcutInfoRepository,
     private val launcherAppsWrapper: LauncherAppsWrapper,
     private val userDataRepository: UserDataRepository,
-    private val shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
-    private val fileManager: FileManager,
-    private val packageManagerWrapper: PackageManagerWrapper,
-    private val iconKeyGenerator: IconKeyGenerator,
+    private val launcherAppsUtil: LauncherAppsUtil,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -67,16 +60,16 @@ class ChangeShortcutsUseCase @Inject constructor(
             val newEblanShortcutInfos = launcherAppsShortcutInfos.map { launcherAppsShortcutInfo ->
                 ensureActive()
 
-                launcherAppsShortcutInfo.toEblanShortcutInfo()
+                launcherAppsUtil.toEblanShortcutInfo(launcherAppsShortcutInfo = launcherAppsShortcutInfo)
             }
 
             if (oldEblanShortcutInfos.toSet() != newEblanShortcutInfos.toSet()) {
                 val newDeleteEblanShortcutInfos = newEblanShortcutInfos.map { eblanShortcutInfo ->
-                    eblanShortcutInfo.toDeleteEblanShortcutInfo()
+                    launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
                 }.toSet()
 
                 val oldDeleteEblanShortcutInfos = oldEblanShortcutInfos.map { eblanShortcutInfo ->
-                    eblanShortcutInfo.toDeleteEblanShortcutInfo()
+                    launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
                 }.filter { deleteEblanShortcutInfo ->
                     deleteEblanShortcutInfo !in newDeleteEblanShortcutInfos
                 }
@@ -89,15 +82,9 @@ class ChangeShortcutsUseCase @Inject constructor(
                     deleteEblanShortcutInfos = oldDeleteEblanShortcutInfos,
                 )
 
-                deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
+                launcherAppsUtil.deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
 
-                updateShortcutInfoGridItems(
-                    eblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos(),
-                    shortcutInfoGridItemRepository = shortcutInfoGridItemRepository,
-                    fileManager = fileManager,
-                    packageManagerWrapper = packageManagerWrapper,
-                    iconKeyGenerator = iconKeyGenerator,
-                )
+                launcherAppsUtil.updateShortcutInfoGridItems()
             }
         }
     }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
@@ -50,6 +50,10 @@ import com.eblan.launcher.domain.model.UpdateShortcutInfoGridItem
 import com.eblan.launcher.domain.model.UpdateWidgetGridItem
 import com.eblan.launcher.domain.model.WidgetGridItem
 import com.eblan.launcher.domain.repository.ApplicationInfoGridItemRepository
+import com.eblan.launcher.domain.repository.EblanAppWidgetProviderInfoRepository
+import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
+import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
+import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.ShortcutConfigGridItemRepository
 import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.WidgetGridItemRepository
@@ -57,171 +61,183 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import java.io.File
+import javax.inject.Inject
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-internal suspend fun deleteEblanApplicationInfoIcons(
-    eblanApplicationInfos: List<EblanApplicationInfo>,
-    eblanAppWidgetProviderInfos: List<EblanAppWidgetProviderInfo>,
-    oldDeleteEblanApplicationInfos: List<DeleteEblanApplicationInfo>,
+class LauncherAppsUtil @Inject internal constructor(
+    private val fileManager: FileManager,
+    private val packageManagerWrapper: PackageManagerWrapper,
+    private val iconKeyGenerator: IconKeyGenerator,
+    private val widgetGridItemRepository: WidgetGridItemRepository,
+    private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
+    private val eblanAppWidgetProviderInfoRepository: EblanAppWidgetProviderInfoRepository,
+    private val applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
+    private val eblanShortcutInfoRepository: EblanShortcutInfoRepository,
+    private val shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
+    private val eblanShortcutConfigRepository: EblanShortcutConfigRepository,
+    private val shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
 ) {
-    oldDeleteEblanApplicationInfos.forEach { oldDeleteEblanApplicationInfo ->
-        currentCoroutineContext().ensureActive()
+    suspend fun deleteEblanApplicationInfoIcons(oldDeleteEblanApplicationInfos: List<DeleteEblanApplicationInfo>) {
+        val eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos()
 
-        val icon = oldDeleteEblanApplicationInfo.icon
+        val eblanAppWidgetProviderInfos =
+            eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos()
 
-        val hasNoIconReference =
-            icon != null && eblanApplicationInfos.none { eblanApplicationInfo ->
-                currentCoroutineContext().ensureActive()
-
-                eblanApplicationInfo.icon == icon
-            } && eblanAppWidgetProviderInfos.none { eblanAppWidgetProviderInfo ->
-                currentCoroutineContext().ensureActive()
-                eblanAppWidgetProviderInfo.applicationIcon == icon
-            }
-
-        if (hasNoIconReference) {
-            val iconFile = File(icon)
-
-            if (iconFile.exists()) {
-                iconFile.delete()
-            }
-        }
-    }
-}
-
-internal suspend fun deleteEblanAppWidgetProviderInfoIcons(
-    eblanApplicationInfos: List<EblanApplicationInfo>,
-    eblanAppWidgetProviderInfos: List<EblanAppWidgetProviderInfo>,
-    oldDeleteEblanAppWidgetProviderInfos: List<DeleteEblanAppWidgetProviderInfo>,
-) {
-    oldDeleteEblanAppWidgetProviderInfos.forEach { deleteEblanAppWidgetProviderInfo ->
-        currentCoroutineContext().ensureActive()
-
-        val applicationIcon = deleteEblanAppWidgetProviderInfo.applicationIcon
-
-        val hasNoIconReference =
-            applicationIcon != null && eblanAppWidgetProviderInfos.none { eblanAppWidgetProviderInfo ->
-                currentCoroutineContext().ensureActive()
-
-                eblanAppWidgetProviderInfo.applicationIcon == applicationIcon
-            } && eblanApplicationInfos.none { eblanApplicationInfo ->
-                currentCoroutineContext().ensureActive()
-
-                eblanApplicationInfo.icon == applicationIcon
-            }
-
-        if (hasNoIconReference) {
-            val iconFile = File(applicationIcon)
-
-            if (iconFile.exists()) {
-                iconFile.delete()
-            }
-        }
-
-        deleteEblanAppWidgetProviderInfo.preview?.let { preview ->
-            val previewFile = File(preview)
-
-            if (previewFile.exists()) {
-                previewFile.delete()
-            }
-        }
-    }
-}
-
-internal suspend fun deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos: List<DeleteEblanShortcutInfo>) {
-    oldDeleteEblanShortcutInfos.forEach { deleteEblanShortcutInfo ->
-        currentCoroutineContext().ensureActive()
-
-        val icon = deleteEblanShortcutInfo.icon
-
-        if (icon != null) {
-            val iconFile = File(icon)
-
-            if (iconFile.exists()) {
-                iconFile.delete()
-            }
-        }
-    }
-}
-
-internal suspend fun deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs: List<DeleteEblanShortcutConfig>) {
-    oldDeleteEblanShortcutConfigs.forEach { deleteEblanShortcutConfig ->
-        currentCoroutineContext().ensureActive()
-
-        val activityIcon = deleteEblanShortcutConfig.activityIcon
-
-        if (activityIcon != null) {
-            val activityIconFile = File(activityIcon)
-
-            if (activityIconFile.exists()) {
-                activityIconFile.delete()
-            }
-        }
-    }
-}
-
-internal suspend fun updateApplicationInfoGridItems(
-    eblanApplicationInfos: List<EblanApplicationInfo>,
-    applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
-) {
-    val updateApplicationInfoGridItems = mutableListOf<UpdateApplicationInfoGridItem>()
-
-    val deleteApplicationInfoGridItems = mutableListOf<ApplicationInfoGridItem>()
-
-    val applicationInfoGridItems =
-        applicationInfoGridItemRepository.applicationInfoGridItems.first()
-
-    applicationInfoGridItems.filterNot { applicationInfoGridItem ->
-        currentCoroutineContext().ensureActive()
-
-        applicationInfoGridItem.override
-    }.forEach { applicationInfoGridItem ->
-        currentCoroutineContext().ensureActive()
-
-        val eblanApplicationInfo = eblanApplicationInfos.find { eblanApplicationInfo ->
+        oldDeleteEblanApplicationInfos.forEach { oldDeleteEblanApplicationInfo ->
             currentCoroutineContext().ensureActive()
 
-            eblanApplicationInfo.serialNumber == applicationInfoGridItem.serialNumber && eblanApplicationInfo.componentName == applicationInfoGridItem.componentName
-        }
+            val icon = oldDeleteEblanApplicationInfo.icon
 
-        if (eblanApplicationInfo != null) {
-            updateApplicationInfoGridItems.add(
-                UpdateApplicationInfoGridItem(
-                    id = applicationInfoGridItem.id,
-                    componentName = eblanApplicationInfo.componentName,
-                    icon = eblanApplicationInfo.icon,
-                    label = eblanApplicationInfo.label,
-                ),
-            )
-        } else {
-            deleteApplicationInfoGridItems.add(applicationInfoGridItem)
+            val hasNoIconReference =
+                icon != null && eblanApplicationInfos.none { eblanApplicationInfo ->
+                    currentCoroutineContext().ensureActive()
+
+                    eblanApplicationInfo.icon == icon
+                } && eblanAppWidgetProviderInfos.none { eblanAppWidgetProviderInfo ->
+                    currentCoroutineContext().ensureActive()
+                    eblanAppWidgetProviderInfo.applicationIcon == icon
+                }
+
+            if (hasNoIconReference) {
+                val iconFile = File(icon)
+
+                if (iconFile.exists()) {
+                    iconFile.delete()
+                }
+            }
         }
     }
 
-    applicationInfoGridItemRepository.updateApplicationInfoGridItems(
-        updateApplicationInfoGridItems = updateApplicationInfoGridItems,
-    )
+    suspend fun deleteEblanAppWidgetProviderInfoIcons(
+        oldDeleteEblanAppWidgetProviderInfos: List<DeleteEblanAppWidgetProviderInfo>,
+    ) {
+        val eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos()
 
-    applicationInfoGridItemRepository.deleteApplicationInfoGridItems(
-        applicationInfoGridItems = deleteApplicationInfoGridItems,
-    )
-}
+        val eblanAppWidgetProviderInfos =
+            eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos()
 
-internal suspend fun updateShortcutInfoGridItems(
-    eblanShortcutInfos: List<EblanShortcutInfo>?,
-    shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    iconKeyGenerator: IconKeyGenerator,
-) {
-    val updateShortcutInfoGridItems = mutableListOf<UpdateShortcutInfoGridItem>()
+        oldDeleteEblanAppWidgetProviderInfos.forEach { deleteEblanAppWidgetProviderInfo ->
+            currentCoroutineContext().ensureActive()
 
-    val deleteShortcutInfoGridItems = mutableListOf<ShortcutInfoGridItem>()
+            val applicationIcon = deleteEblanAppWidgetProviderInfo.applicationIcon
 
-    val shortcutInfoGridItems = shortcutInfoGridItemRepository.shortcutInfoGridItems.first()
+            val hasNoIconReference =
+                applicationIcon != null && eblanAppWidgetProviderInfos.none { eblanAppWidgetProviderInfo ->
+                    currentCoroutineContext().ensureActive()
 
-    if (eblanShortcutInfos != null) {
+                    eblanAppWidgetProviderInfo.applicationIcon == applicationIcon
+                } && eblanApplicationInfos.none { eblanApplicationInfo ->
+                    currentCoroutineContext().ensureActive()
+
+                    eblanApplicationInfo.icon == applicationIcon
+                }
+
+            if (hasNoIconReference) {
+                val iconFile = File(applicationIcon)
+
+                if (iconFile.exists()) {
+                    iconFile.delete()
+                }
+            }
+
+            deleteEblanAppWidgetProviderInfo.preview?.let { preview ->
+                val previewFile = File(preview)
+
+                if (previewFile.exists()) {
+                    previewFile.delete()
+                }
+            }
+        }
+    }
+
+    suspend fun deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos: List<DeleteEblanShortcutInfo>) {
+        oldDeleteEblanShortcutInfos.forEach { deleteEblanShortcutInfo ->
+            currentCoroutineContext().ensureActive()
+
+            val icon = deleteEblanShortcutInfo.icon
+
+            if (icon != null) {
+                val iconFile = File(icon)
+
+                if (iconFile.exists()) {
+                    iconFile.delete()
+                }
+            }
+        }
+    }
+
+    suspend fun deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs: List<DeleteEblanShortcutConfig>) {
+        oldDeleteEblanShortcutConfigs.forEach { deleteEblanShortcutConfig ->
+            currentCoroutineContext().ensureActive()
+
+            val activityIcon = deleteEblanShortcutConfig.activityIcon
+
+            if (activityIcon != null) {
+                val activityIconFile = File(activityIcon)
+
+                if (activityIconFile.exists()) {
+                    activityIconFile.delete()
+                }
+            }
+        }
+    }
+
+    internal suspend fun updateApplicationInfoGridItems() {
+        val eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos()
+
+        val updateApplicationInfoGridItems = mutableListOf<UpdateApplicationInfoGridItem>()
+
+        val deleteApplicationInfoGridItems = mutableListOf<ApplicationInfoGridItem>()
+
+        val applicationInfoGridItems =
+            applicationInfoGridItemRepository.applicationInfoGridItems.first()
+
+        applicationInfoGridItems.filterNot { applicationInfoGridItem ->
+            currentCoroutineContext().ensureActive()
+
+            applicationInfoGridItem.override
+        }.forEach { applicationInfoGridItem ->
+            currentCoroutineContext().ensureActive()
+
+            val eblanApplicationInfo = eblanApplicationInfos.find { eblanApplicationInfo ->
+                currentCoroutineContext().ensureActive()
+
+                eblanApplicationInfo.serialNumber == applicationInfoGridItem.serialNumber && eblanApplicationInfo.componentName == applicationInfoGridItem.componentName
+            }
+
+            if (eblanApplicationInfo != null) {
+                updateApplicationInfoGridItems.add(
+                    UpdateApplicationInfoGridItem(
+                        id = applicationInfoGridItem.id,
+                        componentName = eblanApplicationInfo.componentName,
+                        icon = eblanApplicationInfo.icon,
+                        label = eblanApplicationInfo.label,
+                    ),
+                )
+            } else {
+                deleteApplicationInfoGridItems.add(applicationInfoGridItem)
+            }
+        }
+
+        applicationInfoGridItemRepository.updateApplicationInfoGridItems(
+            updateApplicationInfoGridItems = updateApplicationInfoGridItems,
+        )
+
+        applicationInfoGridItemRepository.deleteApplicationInfoGridItems(
+            applicationInfoGridItems = deleteApplicationInfoGridItems,
+        )
+    }
+
+    internal suspend fun updateShortcutInfoGridItems() {
+        val eblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos()
+
+        val updateShortcutInfoGridItems = mutableListOf<UpdateShortcutInfoGridItem>()
+
+        val deleteShortcutInfoGridItems = mutableListOf<ShortcutInfoGridItem>()
+
+        val shortcutInfoGridItems = shortcutInfoGridItemRepository.shortcutInfoGridItems.first()
+
         shortcutInfoGridItems.filterNot { shortcutInfoGridItem ->
             shortcutInfoGridItem.override
         }.forEach { shortcutInfoGridItem ->
@@ -242,9 +258,6 @@ internal suspend fun updateShortcutInfoGridItems(
                         isEnabled = eblanShortcutInfo.isEnabled,
                         icon = eblanShortcutInfo.icon,
                         eblanApplicationInfoIcon = resolveApplicationIcon(
-                            fileManager = fileManager,
-                            packageManagerWrapper = packageManagerWrapper,
-                            iconKeyGenerator = iconKeyGenerator,
                             serialNumber = eblanShortcutInfo.serialNumber,
                             packageName = eblanShortcutInfo.packageName,
                         ),
@@ -261,381 +274,356 @@ internal suspend fun updateShortcutInfoGridItems(
 
         shortcutInfoGridItemRepository.deleteShortcutInfoGridItems(shortcutInfoGridItems = deleteShortcutInfoGridItems)
     }
-}
 
-internal suspend fun updateShortcutConfigGridItems(
-    eblanShortcutConfigs: List<EblanShortcutConfig>,
-    shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    iconKeyGenerator: IconKeyGenerator,
-) {
-    val updateShortcutConfigGridItems = mutableListOf<UpdateShortcutConfigGridItem>()
+    internal suspend fun updateShortcutConfigGridItems() {
+        val eblanShortcutConfigs = eblanShortcutConfigRepository.getEblanShortcutConfigs()
 
-    val deleteShortcutConfigGridItems = mutableListOf<ShortcutConfigGridItem>()
+        val updateShortcutConfigGridItems = mutableListOf<UpdateShortcutConfigGridItem>()
 
-    val shortcutConfigGridItems = shortcutConfigGridItemRepository.shortcutConfigGridItems.first()
+        val deleteShortcutConfigGridItems = mutableListOf<ShortcutConfigGridItem>()
 
-    shortcutConfigGridItems.filterNot { shortcutConfigGridItem ->
-        shortcutConfigGridItem.override
-    }.forEach { shortcutConfigGridItem ->
-        currentCoroutineContext().ensureActive()
+        val shortcutConfigGridItems =
+            shortcutConfigGridItemRepository.shortcutConfigGridItems.first()
 
-        val eblanShortcutConfig = eblanShortcutConfigs.find { eblanShortcutConfig ->
+        shortcutConfigGridItems.filterNot { shortcutConfigGridItem ->
+            shortcutConfigGridItem.override
+        }.forEach { shortcutConfigGridItem ->
             currentCoroutineContext().ensureActive()
 
-            eblanShortcutConfig.serialNumber == shortcutConfigGridItem.serialNumber && eblanShortcutConfig.componentName == shortcutConfigGridItem.componentName
-        }
-
-        if (eblanShortcutConfig != null) {
-            updateShortcutConfigGridItems.add(
-                UpdateShortcutConfigGridItem(
-                    id = shortcutConfigGridItem.id,
-                    componentName = eblanShortcutConfig.componentName,
-                    activityLabel = eblanShortcutConfig.activityLabel,
-                    activityIcon = eblanShortcutConfig.activityIcon,
-                    applicationLabel = packageManagerWrapper.getApplicationLabel(
-                        packageName = eblanShortcutConfig.packageName,
-                    ).toString(),
-                    applicationIcon = resolveApplicationIcon(
-                        fileManager = fileManager,
-                        packageManagerWrapper = packageManagerWrapper,
-                        iconKeyGenerator = iconKeyGenerator,
-                        serialNumber = eblanShortcutConfig.serialNumber,
-                        packageName = eblanShortcutConfig.packageName,
-                    ),
-                ),
-            )
-        } else {
-            deleteShortcutConfigGridItems.add(shortcutConfigGridItem)
-        }
-    }
-
-    shortcutConfigGridItemRepository.updateShortcutConfigGridItems(
-        updateShortcutConfigGridItems = updateShortcutConfigGridItems,
-    )
-
-    shortcutConfigGridItemRepository.deleteShortcutConfigGridItems(
-        shortcutConfigGridItems = deleteShortcutConfigGridItems,
-    )
-}
-
-internal suspend fun updateWidgetGridItems(
-    eblanAppWidgetProviderInfos: List<EblanAppWidgetProviderInfo>,
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    widgetGridItemRepository: WidgetGridItemRepository,
-    iconKeyGenerator: IconKeyGenerator,
-) {
-    if (!packageManagerWrapper.hasSystemFeatureAppWidgets) return
-
-    val updateWidgetGridItems = mutableListOf<UpdateWidgetGridItem>()
-
-    val deleteWidgetGridItems = mutableListOf<WidgetGridItem>()
-
-    val widgetGridItems = widgetGridItemRepository.widgetGridItems.first()
-
-    widgetGridItems.filterNot { widgetGridItem ->
-        widgetGridItem.override
-    }.forEach { widgetGridItem ->
-        currentCoroutineContext().ensureActive()
-
-        val eblanAppWidgetProviderInfo =
-            eblanAppWidgetProviderInfos.find { eblanAppWidgetProviderInfo ->
+            val eblanShortcutConfig = eblanShortcutConfigs.find { eblanShortcutConfig ->
                 currentCoroutineContext().ensureActive()
 
-                eblanAppWidgetProviderInfo.serialNumber == widgetGridItem.serialNumber && eblanAppWidgetProviderInfo.componentName == widgetGridItem.componentName
+                eblanShortcutConfig.serialNumber == shortcutConfigGridItem.serialNumber && eblanShortcutConfig.componentName == shortcutConfigGridItem.componentName
             }
 
-        if (eblanAppWidgetProviderInfo != null) {
-            updateWidgetGridItems.add(
-                UpdateWidgetGridItem(
-                    id = widgetGridItem.id,
-                    componentName = eblanAppWidgetProviderInfo.componentName,
-                    configure = eblanAppWidgetProviderInfo.configure,
-                    minWidth = eblanAppWidgetProviderInfo.minWidth,
-                    minHeight = eblanAppWidgetProviderInfo.minHeight,
-                    resizeMode = eblanAppWidgetProviderInfo.resizeMode,
-                    minResizeWidth = eblanAppWidgetProviderInfo.minResizeWidth,
-                    minResizeHeight = eblanAppWidgetProviderInfo.minResizeHeight,
-                    maxResizeWidth = eblanAppWidgetProviderInfo.maxResizeWidth,
-                    maxResizeHeight = eblanAppWidgetProviderInfo.maxResizeHeight,
-                    targetCellHeight = eblanAppWidgetProviderInfo.targetCellHeight,
-                    targetCellWidth = eblanAppWidgetProviderInfo.targetCellWidth,
-                    icon = resolveApplicationIcon(
-                        fileManager = fileManager,
-                        packageManagerWrapper = packageManagerWrapper,
-                        iconKeyGenerator = iconKeyGenerator,
-                        serialNumber = eblanAppWidgetProviderInfo.serialNumber,
-                        packageName = eblanAppWidgetProviderInfo.packageName,
+            if (eblanShortcutConfig != null) {
+                updateShortcutConfigGridItems.add(
+                    UpdateShortcutConfigGridItem(
+                        id = shortcutConfigGridItem.id,
+                        componentName = eblanShortcutConfig.componentName,
+                        activityLabel = eblanShortcutConfig.activityLabel,
+                        activityIcon = eblanShortcutConfig.activityIcon,
+                        applicationLabel = packageManagerWrapper.getApplicationLabel(
+                            packageName = eblanShortcutConfig.packageName,
+                        ).toString(),
+                        applicationIcon = resolveApplicationIcon(
+                            serialNumber = eblanShortcutConfig.serialNumber,
+                            packageName = eblanShortcutConfig.packageName,
+                        ),
                     ),
-                    label = packageManagerWrapper.getApplicationLabel(
-                        packageName = eblanAppWidgetProviderInfo.packageName,
-                    ).toString(),
-                ),
-            )
-        } else {
-            deleteWidgetGridItems.add(widgetGridItem)
+                )
+            } else {
+                deleteShortcutConfigGridItems.add(shortcutConfigGridItem)
+            }
         }
-    }
 
-    widgetGridItemRepository.updateWidgetGridItems(updateWidgetGridItems = updateWidgetGridItems)
+        shortcutConfigGridItemRepository.updateShortcutConfigGridItems(
+            updateShortcutConfigGridItems = updateShortcutConfigGridItems,
+        )
 
-    widgetGridItemRepository.deleteWidgetGridItemsByPackageName(widgetGridItems = deleteWidgetGridItems)
-}
-
-internal suspend fun AppWidgetManagerAppWidgetProviderInfo.toEblanAppWidgetProviderInfo(
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    iconKeyGenerator: IconKeyGenerator,
-): EblanAppWidgetProviderInfo = EblanAppWidgetProviderInfo(
-    componentName = componentName,
-    serialNumber = serialNumber,
-    configure = configure,
-    packageName = packageName,
-    targetCellWidth = targetCellWidth,
-    targetCellHeight = targetCellHeight,
-    minWidth = minWidth,
-    minHeight = minHeight,
-    resizeMode = resizeMode,
-    minResizeWidth = minResizeWidth,
-    minResizeHeight = minResizeHeight,
-    maxResizeWidth = maxResizeWidth,
-    maxResizeHeight = maxResizeHeight,
-    preview = preview,
-    applicationIcon = resolveApplicationIcon(
-        fileManager = fileManager,
-        packageManagerWrapper = packageManagerWrapper,
-        iconKeyGenerator = iconKeyGenerator,
-        serialNumber = serialNumber,
-        packageName = packageName,
-    ),
-    applicationLabel = packageManagerWrapper.getApplicationLabel(
-        packageName = packageName,
-    ).toString(),
-    lastUpdateTime = lastUpdateTime,
-    label = label,
-    description = description,
-)
-
-internal fun EblanApplicationInfo.toFastLauncherAppsActivityInfo(): FastLauncherAppsActivityInfo = FastLauncherAppsActivityInfo(
-    serialNumber = serialNumber,
-    componentName = componentName,
-    packageName = packageName,
-    lastUpdateTime = lastUpdateTime,
-)
-
-internal fun EblanApplicationInfo.toSyncEblanApplicationInfo() = SyncEblanApplicationInfo(
-    serialNumber = serialNumber,
-    componentName = componentName,
-    packageName = packageName,
-    icon = icon,
-    label = label,
-    lastUpdateTime = lastUpdateTime,
-)
-
-internal fun LauncherAppsActivityInfo.toSyncEblanApplicationInfo() = SyncEblanApplicationInfo(
-    serialNumber = serialNumber,
-    componentName = componentName,
-    packageName = packageName,
-    icon = activityIcon,
-    label = activityLabel,
-    lastUpdateTime = lastUpdateTime,
-)
-
-internal fun SyncEblanApplicationInfo.toDeleteEblanApplicationInfo() = DeleteEblanApplicationInfo(
-    serialNumber = serialNumber,
-    componentName = componentName,
-    packageName = packageName,
-    icon = icon,
-)
-
-internal suspend fun ShortcutConfigActivityInfo.toEblanShortcutConfig(
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    iconKeyGenerator: IconKeyGenerator,
-): EblanShortcutConfig = EblanShortcutConfig(
-    componentName = componentName,
-    packageName = packageName,
-    serialNumber = serialNumber,
-    activityIcon = activityIcon,
-    activityLabel = activityLabel,
-    applicationIcon = resolveApplicationIcon(
-        fileManager = fileManager,
-        packageManagerWrapper = packageManagerWrapper,
-        iconKeyGenerator = iconKeyGenerator,
-        serialNumber = serialNumber,
-        packageName = packageName,
-    ),
-    applicationLabel = packageManagerWrapper.getApplicationLabel(
-        packageName = packageName,
-    ),
-)
-
-internal fun EblanAppWidgetProviderInfo.toDeleteEblanAppWidgetProviderInfo(): DeleteEblanAppWidgetProviderInfo = DeleteEblanAppWidgetProviderInfo(
-    componentName = componentName,
-    serialNumber = serialNumber,
-    packageName = packageName,
-    preview = preview,
-    applicationIcon = applicationIcon,
-)
-
-internal fun LauncherAppsShortcutInfo.toEblanShortcutInfo(): EblanShortcutInfo = EblanShortcutInfo(
-    shortcutId = shortcutId,
-    serialNumber = serialNumber,
-    packageName = packageName,
-    shortLabel = shortLabel,
-    longLabel = longLabel,
-    icon = icon,
-    shortcutQueryFlag = shortcutQueryFlag,
-    isEnabled = isEnabled,
-    lastChangedTimestamp = lastChangedTimestamp,
-)
-
-internal fun EblanShortcutInfo.toDeleteEblanShortcutInfo(): DeleteEblanShortcutInfo = DeleteEblanShortcutInfo(
-    serialNumber = serialNumber,
-    shortcutId = shortcutId,
-    packageName = packageName,
-    icon = icon,
-)
-
-internal fun EblanShortcutConfig.toDeleteEblanShortcutConfig(): DeleteEblanShortcutConfig = DeleteEblanShortcutConfig(
-    componentName = componentName,
-    packageName = packageName,
-    serialNumber = serialNumber,
-    activityIcon = activityIcon,
-)
-
-@OptIn(ExperimentalUuidApi::class)
-internal suspend fun addNewApplicationToHomeScreen(
-    gridItems: MutableList<GridItem>,
-    componentName: String,
-    packageName: String,
-    icon: String?,
-    label: String?,
-    homeSettings: HomeSettings,
-    newApplicationsToHomeScreen: MutableList<ApplicationInfoGridItem>,
-) {
-    val alreadyOnHome = gridItems.any { gridItem ->
-        when (val data = gridItem.data) {
-            is GridItemData.ApplicationInfo ->
-                data.serialNumber == 0L &&
-                    data.componentName == componentName
-
-            is GridItemData.Folder ->
-                data.gridItems.any { gridItem ->
-                    gridItem.serialNumber == 0L &&
-                        gridItem.componentName == componentName
-                }
-
-            else -> false
-        }
-    }
-
-    if (alreadyOnHome) return
-
-    val eblanAction = EblanAction(
-        eblanActionType = EblanActionType.None,
-        serialNumber = 0L,
-        componentName = "",
-    )
-
-    val data = GridItemData.ApplicationInfo(
-        serialNumber = 0L,
-        componentName = componentName,
-        packageName = packageName,
-        icon = icon,
-        label = label.toString(),
-        customIcon = null,
-        customLabel = null,
-        index = -1,
-        folderId = null,
-    )
-
-    val gridItem = GridItem(
-        id = Uuid.random().toHexString(),
-        page = homeSettings.initialPage,
-        startColumn = 0,
-        startRow = 0,
-        columnSpan = 1,
-        rowSpan = 1,
-        data = data,
-        associate = Associate.Grid,
-        override = false,
-        gridItemSettings = homeSettings.gridItemSettings,
-        doubleTap = eblanAction,
-        swipeUp = eblanAction,
-        swipeDown = eblanAction,
-    )
-
-    val newGridItem = findAvailableRegionByPage(
-        gridItems = gridItems,
-        gridItem = gridItem,
-        pageCount = homeSettings.pageCount,
-        columns = homeSettings.columns,
-        rows = homeSettings.rows,
-    )
-
-    if (newGridItem != null) {
-        gridItems.add(newGridItem)
-
-        newApplicationsToHomeScreen.add(
-            ApplicationInfoGridItem(
-                id = newGridItem.id,
-                page = newGridItem.page,
-                startColumn = newGridItem.startColumn,
-                startRow = newGridItem.startRow,
-                columnSpan = newGridItem.columnSpan,
-                rowSpan = newGridItem.rowSpan,
-                associate = newGridItem.associate,
-                componentName = data.componentName,
-                packageName = data.packageName,
-                icon = data.icon,
-                label = data.label,
-                override = newGridItem.override,
-                serialNumber = data.serialNumber,
-                customIcon = data.customIcon,
-                customLabel = data.customLabel,
-                gridItemSettings = newGridItem.gridItemSettings,
-                doubleTap = newGridItem.doubleTap,
-                swipeUp = newGridItem.swipeUp,
-                swipeDown = newGridItem.swipeDown,
-                index = data.index,
-                folderId = data.folderId,
-            ),
+        shortcutConfigGridItemRepository.deleteShortcutConfigGridItems(
+            shortcutConfigGridItems = deleteShortcutConfigGridItems,
         )
     }
-}
 
-private suspend fun resolveApplicationIcon(
-    fileManager: FileManager,
-    packageManagerWrapper: PackageManagerWrapper,
-    iconKeyGenerator: IconKeyGenerator,
-    serialNumber: Long,
-    packageName: String,
-): String? {
-    val directory = fileManager.getFilesDirectory(FileManager.ICONS_DIR)
+    internal suspend fun updateWidgetGridItems() {
+        if (!packageManagerWrapper.hasSystemFeatureAppWidgets) return
 
-    val componentName = packageManagerWrapper.getComponentName(packageName = packageName)
+        val eblanAppWidgetProviderInfos =
+            eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos()
 
-    return if (componentName != null) {
-        File(
-            directory,
-            iconKeyGenerator.getActivityIconKey(
-                serialNumber = serialNumber,
-                componentName = componentName,
-            ),
-        ).absolutePath
-    } else {
-        val file =
+        val updateWidgetGridItems = mutableListOf<UpdateWidgetGridItem>()
+
+        val deleteWidgetGridItems = mutableListOf<WidgetGridItem>()
+
+        val widgetGridItems = widgetGridItemRepository.widgetGridItems.first()
+
+        widgetGridItems.filterNot { widgetGridItem ->
+            widgetGridItem.override
+        }.forEach { widgetGridItem ->
+            currentCoroutineContext().ensureActive()
+
+            val eblanAppWidgetProviderInfo =
+                eblanAppWidgetProviderInfos.find { eblanAppWidgetProviderInfo ->
+                    currentCoroutineContext().ensureActive()
+
+                    eblanAppWidgetProviderInfo.serialNumber == widgetGridItem.serialNumber && eblanAppWidgetProviderInfo.componentName == widgetGridItem.componentName
+                }
+
+            if (eblanAppWidgetProviderInfo != null) {
+                updateWidgetGridItems.add(
+                    UpdateWidgetGridItem(
+                        id = widgetGridItem.id,
+                        componentName = eblanAppWidgetProviderInfo.componentName,
+                        configure = eblanAppWidgetProviderInfo.configure,
+                        minWidth = eblanAppWidgetProviderInfo.minWidth,
+                        minHeight = eblanAppWidgetProviderInfo.minHeight,
+                        resizeMode = eblanAppWidgetProviderInfo.resizeMode,
+                        minResizeWidth = eblanAppWidgetProviderInfo.minResizeWidth,
+                        minResizeHeight = eblanAppWidgetProviderInfo.minResizeHeight,
+                        maxResizeWidth = eblanAppWidgetProviderInfo.maxResizeWidth,
+                        maxResizeHeight = eblanAppWidgetProviderInfo.maxResizeHeight,
+                        targetCellHeight = eblanAppWidgetProviderInfo.targetCellHeight,
+                        targetCellWidth = eblanAppWidgetProviderInfo.targetCellWidth,
+                        icon = resolveApplicationIcon(
+                            serialNumber = eblanAppWidgetProviderInfo.serialNumber,
+                            packageName = eblanAppWidgetProviderInfo.packageName,
+                        ),
+                        label = packageManagerWrapper.getApplicationLabel(
+                            packageName = eblanAppWidgetProviderInfo.packageName,
+                        ).toString(),
+                    ),
+                )
+            } else {
+                deleteWidgetGridItems.add(widgetGridItem)
+            }
+        }
+
+        widgetGridItemRepository.updateWidgetGridItems(updateWidgetGridItems = updateWidgetGridItems)
+
+        widgetGridItemRepository.deleteWidgetGridItemsByPackageName(widgetGridItems = deleteWidgetGridItems)
+    }
+
+    internal suspend fun toEblanAppWidgetProviderInfo(
+        appWidgetManagerAppWidgetProviderInfo: AppWidgetManagerAppWidgetProviderInfo,
+    ): EblanAppWidgetProviderInfo = EblanAppWidgetProviderInfo(
+        componentName = appWidgetManagerAppWidgetProviderInfo.componentName,
+        serialNumber = appWidgetManagerAppWidgetProviderInfo.serialNumber,
+        configure = appWidgetManagerAppWidgetProviderInfo.configure,
+        packageName = appWidgetManagerAppWidgetProviderInfo.packageName,
+        targetCellWidth = appWidgetManagerAppWidgetProviderInfo.targetCellWidth,
+        targetCellHeight = appWidgetManagerAppWidgetProviderInfo.targetCellHeight,
+        minWidth = appWidgetManagerAppWidgetProviderInfo.minWidth,
+        minHeight = appWidgetManagerAppWidgetProviderInfo.minHeight,
+        resizeMode = appWidgetManagerAppWidgetProviderInfo.resizeMode,
+        minResizeWidth = appWidgetManagerAppWidgetProviderInfo.minResizeWidth,
+        minResizeHeight = appWidgetManagerAppWidgetProviderInfo.minResizeHeight,
+        maxResizeWidth = appWidgetManagerAppWidgetProviderInfo.maxResizeWidth,
+        maxResizeHeight = appWidgetManagerAppWidgetProviderInfo.maxResizeHeight,
+        preview = appWidgetManagerAppWidgetProviderInfo.preview,
+        applicationIcon = resolveApplicationIcon(
+            serialNumber = appWidgetManagerAppWidgetProviderInfo.serialNumber,
+            packageName = appWidgetManagerAppWidgetProviderInfo.packageName,
+        ),
+        applicationLabel = packageManagerWrapper.getApplicationLabel(
+            packageName = appWidgetManagerAppWidgetProviderInfo.packageName,
+        ).toString(),
+        lastUpdateTime = appWidgetManagerAppWidgetProviderInfo.lastUpdateTime,
+        label = appWidgetManagerAppWidgetProviderInfo.label,
+        description = appWidgetManagerAppWidgetProviderInfo.description,
+    )
+
+    internal fun toFastLauncherAppsActivityInfo(eblanApplicationInfo: EblanApplicationInfo): FastLauncherAppsActivityInfo = FastLauncherAppsActivityInfo(
+        serialNumber = eblanApplicationInfo.serialNumber,
+        componentName = eblanApplicationInfo.componentName,
+        packageName = eblanApplicationInfo.packageName,
+        lastUpdateTime = eblanApplicationInfo.lastUpdateTime,
+    )
+
+    internal fun toSyncEblanApplicationInfo(eblanApplicationInfo: EblanApplicationInfo) = SyncEblanApplicationInfo(
+        serialNumber = eblanApplicationInfo.serialNumber,
+        componentName = eblanApplicationInfo.componentName,
+        packageName = eblanApplicationInfo.packageName,
+        icon = eblanApplicationInfo.icon,
+        label = eblanApplicationInfo.label,
+        lastUpdateTime = eblanApplicationInfo.lastUpdateTime,
+    )
+
+    internal fun toSyncEblanApplicationInfo(launcherAppsActivityInfo: LauncherAppsActivityInfo) = SyncEblanApplicationInfo(
+        serialNumber = launcherAppsActivityInfo.serialNumber,
+        componentName = launcherAppsActivityInfo.componentName,
+        packageName = launcherAppsActivityInfo.packageName,
+        icon = launcherAppsActivityInfo.activityIcon,
+        label = launcherAppsActivityInfo.activityLabel,
+        lastUpdateTime = launcherAppsActivityInfo.lastUpdateTime,
+    )
+
+    internal fun toDeleteEblanApplicationInfo(syncEblanApplicationInfo: SyncEblanApplicationInfo) = DeleteEblanApplicationInfo(
+        serialNumber = syncEblanApplicationInfo.serialNumber,
+        componentName = syncEblanApplicationInfo.componentName,
+        packageName = syncEblanApplicationInfo.packageName,
+        icon = syncEblanApplicationInfo.icon,
+    )
+
+    internal suspend fun toEblanShortcutConfig(
+        shortcutConfigActivityInfo: ShortcutConfigActivityInfo,
+    ): EblanShortcutConfig = EblanShortcutConfig(
+        componentName = shortcutConfigActivityInfo.componentName,
+        packageName = shortcutConfigActivityInfo.packageName,
+        serialNumber = shortcutConfigActivityInfo.serialNumber,
+        activityIcon = shortcutConfigActivityInfo.activityIcon,
+        activityLabel = shortcutConfigActivityInfo.activityLabel,
+        applicationIcon = resolveApplicationIcon(
+            serialNumber = shortcutConfigActivityInfo.serialNumber,
+            packageName = shortcutConfigActivityInfo.packageName,
+        ),
+        applicationLabel = packageManagerWrapper.getApplicationLabel(
+            packageName = shortcutConfigActivityInfo.packageName,
+        ),
+    )
+
+    internal fun toDeleteEblanAppWidgetProviderInfo(eblanAppWidgetProviderInfo: EblanAppWidgetProviderInfo): DeleteEblanAppWidgetProviderInfo = DeleteEblanAppWidgetProviderInfo(
+        componentName = eblanAppWidgetProviderInfo.componentName,
+        serialNumber = eblanAppWidgetProviderInfo.serialNumber,
+        packageName = eblanAppWidgetProviderInfo.packageName,
+        preview = eblanAppWidgetProviderInfo.preview,
+        applicationIcon = eblanAppWidgetProviderInfo.applicationIcon,
+    )
+
+    internal fun toEblanShortcutInfo(launcherAppsShortcutInfo: LauncherAppsShortcutInfo): EblanShortcutInfo = EblanShortcutInfo(
+        shortcutId = launcherAppsShortcutInfo.shortcutId,
+        serialNumber = launcherAppsShortcutInfo.serialNumber,
+        packageName = launcherAppsShortcutInfo.packageName,
+        shortLabel = launcherAppsShortcutInfo.shortLabel,
+        longLabel = launcherAppsShortcutInfo.longLabel,
+        icon = launcherAppsShortcutInfo.icon,
+        shortcutQueryFlag = launcherAppsShortcutInfo.shortcutQueryFlag,
+        isEnabled = launcherAppsShortcutInfo.isEnabled,
+        lastChangedTimestamp = launcherAppsShortcutInfo.lastChangedTimestamp,
+    )
+
+    internal fun toDeleteEblanShortcutInfo(eblanShortcutInfo: EblanShortcutInfo): DeleteEblanShortcutInfo = DeleteEblanShortcutInfo(
+        serialNumber = eblanShortcutInfo.serialNumber,
+        shortcutId = eblanShortcutInfo.shortcutId,
+        packageName = eblanShortcutInfo.packageName,
+        icon = eblanShortcutInfo.icon,
+    )
+
+    internal fun toDeleteEblanShortcutConfig(eblanShortcutConfig: EblanShortcutConfig): DeleteEblanShortcutConfig = DeleteEblanShortcutConfig(
+        componentName = eblanShortcutConfig.componentName,
+        packageName = eblanShortcutConfig.packageName,
+        serialNumber = eblanShortcutConfig.serialNumber,
+        activityIcon = eblanShortcutConfig.activityIcon,
+    )
+
+    @OptIn(ExperimentalUuidApi::class)
+    internal suspend fun addNewApplicationToHomeScreen(
+        gridItems: MutableList<GridItem>,
+        componentName: String,
+        packageName: String,
+        icon: String?,
+        label: String?,
+        homeSettings: HomeSettings,
+        newApplicationsToHomeScreen: MutableList<ApplicationInfoGridItem>,
+    ) {
+        val alreadyOnHome = gridItems.any { gridItem ->
+            when (val data = gridItem.data) {
+                is GridItemData.ApplicationInfo ->
+                    data.serialNumber == 0L &&
+                        data.componentName == componentName
+
+                is GridItemData.Folder ->
+                    data.gridItems.any { gridItem ->
+                        gridItem.serialNumber == 0L &&
+                            gridItem.componentName == componentName
+                    }
+
+                else -> false
+            }
+        }
+
+        if (alreadyOnHome) return
+
+        val eblanAction = EblanAction(
+            eblanActionType = EblanActionType.None,
+            serialNumber = 0L,
+            componentName = "",
+        )
+
+        val data = GridItemData.ApplicationInfo(
+            serialNumber = 0L,
+            componentName = componentName,
+            packageName = packageName,
+            icon = icon,
+            label = label.toString(),
+            customIcon = null,
+            customLabel = null,
+            index = -1,
+            folderId = null,
+        )
+
+        val gridItem = GridItem(
+            id = Uuid.random().toHexString(),
+            page = homeSettings.initialPage,
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+            data = data,
+            associate = Associate.Grid,
+            override = false,
+            gridItemSettings = homeSettings.gridItemSettings,
+            doubleTap = eblanAction,
+            swipeUp = eblanAction,
+            swipeDown = eblanAction,
+        )
+
+        val newGridItem = findAvailableRegionByPage(
+            gridItems = gridItems,
+            gridItem = gridItem,
+            pageCount = homeSettings.pageCount,
+            columns = homeSettings.columns,
+            rows = homeSettings.rows,
+        )
+
+        if (newGridItem != null) {
+            gridItems.add(newGridItem)
+
+            newApplicationsToHomeScreen.add(
+                ApplicationInfoGridItem(
+                    id = newGridItem.id,
+                    page = newGridItem.page,
+                    startColumn = newGridItem.startColumn,
+                    startRow = newGridItem.startRow,
+                    columnSpan = newGridItem.columnSpan,
+                    rowSpan = newGridItem.rowSpan,
+                    associate = newGridItem.associate,
+                    componentName = data.componentName,
+                    packageName = data.packageName,
+                    icon = data.icon,
+                    label = data.label,
+                    override = newGridItem.override,
+                    serialNumber = data.serialNumber,
+                    customIcon = data.customIcon,
+                    customLabel = data.customLabel,
+                    gridItemSettings = newGridItem.gridItemSettings,
+                    doubleTap = newGridItem.doubleTap,
+                    swipeUp = newGridItem.swipeUp,
+                    swipeDown = newGridItem.swipeDown,
+                    index = data.index,
+                    folderId = data.folderId,
+                ),
+            )
+        }
+    }
+
+    private suspend fun resolveApplicationIcon(
+        serialNumber: Long,
+        packageName: String,
+    ): String? {
+        val directory = fileManager.getFilesDirectory(FileManager.ICONS_DIR)
+
+        val componentName = packageManagerWrapper.getComponentName(packageName = packageName)
+
+        return if (componentName != null) {
             File(
                 directory,
                 iconKeyGenerator.getActivityIconKey(
                     serialNumber = serialNumber,
-                    componentName = packageName,
+                    componentName = componentName,
                 ),
-            )
+            ).absolutePath
+        } else {
+            val file =
+                File(
+                    directory,
+                    iconKeyGenerator.getActivityIconKey(
+                        serialNumber = serialNumber,
+                        componentName = packageName,
+                    ),
+                )
 
-        packageManagerWrapper.getApplicationIcon(packageName = packageName, file = file)
+            packageManagerWrapper.getApplicationIcon(packageName = packageName, file = file)
+        }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -19,10 +19,7 @@ package com.eblan.launcher.domain.usecase.launcherapps
 
 import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
-import com.eblan.launcher.domain.common.IconKeyGenerator
 import com.eblan.launcher.domain.framework.AppWidgetManagerWrapper
-import com.eblan.launcher.domain.framework.FileManager
-import com.eblan.launcher.domain.framework.IconPackManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.model.ApplicationInfoGridItem
@@ -43,12 +40,9 @@ import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.GridRepository
-import com.eblan.launcher.domain.repository.ShortcutConfigGridItemRepository
-import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.repository.WidgetGridItemRepository
 import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsUseCase
-import com.eblan.launcher.domain.usecase.iconpack.updateIconPackInfos
+import com.eblan.launcher.domain.usecase.iconpack.IconPackInfoUseCaseUtil
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -63,20 +57,16 @@ class SyncDataUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
     private val eblanApplicationInfoRepository: EblanApplicationInfoRepository,
     private val launcherAppsWrapper: LauncherAppsWrapper,
-    private val fileManager: FileManager,
     private val eblanAppWidgetProviderInfoRepository: EblanAppWidgetProviderInfoRepository,
     private val appWidgetManagerWrapper: AppWidgetManagerWrapper,
     private val packageManagerWrapper: PackageManagerWrapper,
     private val eblanShortcutInfoRepository: EblanShortcutInfoRepository,
     private val applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
-    private val widgetGridItemRepository: WidgetGridItemRepository,
-    private val shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
     private val eblanShortcutConfigRepository: EblanShortcutConfigRepository,
-    private val iconPackManager: IconPackManager,
-    private val shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
-    private val iconKeyGenerator: IconKeyGenerator,
     private val gridRepository: GridRepository,
     private val getFolderGridItemsUseCase: GetFolderGridItemsUseCase,
+    private val iconPackInfoUseCaseUtil: IconPackInfoUseCaseUtil,
+    private val launcherAppsUtil: LauncherAppsUtil,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke() {
@@ -102,12 +92,8 @@ class SyncDataUseCase @Inject constructor(
             }
 
             launch {
-                updateIconPackInfos(
+                iconPackInfoUseCaseUtil.updateIconPackInfos(
                     iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
-                    fileManager = fileManager,
-                    iconPackManager = iconPackManager,
-                    fastLauncherAppsActivityInfos = fastLauncherAppsActivityInfos,
-                    iconKeyGenerator = iconKeyGenerator,
                 )
             }
         }
@@ -121,7 +107,7 @@ class SyncDataUseCase @Inject constructor(
     ) {
         val oldFastEblanLauncherAppsActivityInfo =
             eblanApplicationInfoRepository.getEblanApplicationInfos().map { eblanApplicationInfo ->
-                eblanApplicationInfo.toFastLauncherAppsActivityInfo()
+                launcherAppsUtil.toFastLauncherAppsActivityInfo(eblanApplicationInfo = eblanApplicationInfo)
             }
 
         if (oldFastEblanLauncherAppsActivityInfo.toSet() == fastLauncherAppsActivityInfos.toSet()) return
@@ -132,7 +118,7 @@ class SyncDataUseCase @Inject constructor(
 
         val oldSyncEblanApplicationInfos =
             eblanApplicationInfoRepository.getEblanApplicationInfos().map { eblanApplicationInfo ->
-                eblanApplicationInfo.toSyncEblanApplicationInfo()
+                launcherAppsUtil.toSyncEblanApplicationInfo(eblanApplicationInfo = eblanApplicationInfo)
             }
 
         val newSyncEblanApplicationInfos = buildList {
@@ -146,15 +132,13 @@ class SyncDataUseCase @Inject constructor(
                     ).map { shortcutConfigActivityInfo ->
                         currentCoroutineContext().ensureActive()
 
-                        shortcutConfigActivityInfo.toEblanShortcutConfig(
-                            fileManager = fileManager,
-                            packageManagerWrapper = packageManagerWrapper,
-                            iconKeyGenerator = iconKeyGenerator,
+                        launcherAppsUtil.toEblanShortcutConfig(
+                            shortcutConfigActivityInfo = shortcutConfigActivityInfo,
                         )
                     },
                 )
 
-                add(launcherAppsActivityInfo.toSyncEblanApplicationInfo())
+                add(launcherAppsUtil.toSyncEblanApplicationInfo(launcherAppsActivityInfo = launcherAppsActivityInfo))
             }
         }
 
@@ -168,12 +152,12 @@ class SyncDataUseCase @Inject constructor(
 
         val newDeleteEblanApplicationInfos =
             newSyncEblanApplicationInfos.map { syncEblanApplicationInfo ->
-                syncEblanApplicationInfo.toDeleteEblanApplicationInfo()
+                launcherAppsUtil.toDeleteEblanApplicationInfo(syncEblanApplicationInfo = syncEblanApplicationInfo)
             }.toSet()
 
         val oldDeleteEblanApplicationInfos =
             oldSyncEblanApplicationInfos.map { syncEblanApplicationInfo ->
-                syncEblanApplicationInfo.toDeleteEblanApplicationInfo()
+                launcherAppsUtil.toDeleteEblanApplicationInfo(syncEblanApplicationInfo = syncEblanApplicationInfo)
             }
                 .filter { deleteEblanApplicationInfo -> deleteEblanApplicationInfo !in newDeleteEblanApplicationInfos }
 
@@ -185,18 +169,13 @@ class SyncDataUseCase @Inject constructor(
             deleteEblanApplicationInfos = oldDeleteEblanApplicationInfos,
         )
 
-        deleteEblanApplicationInfoIcons(
-            eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-            eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
+        launcherAppsUtil.deleteEblanApplicationInfoIcons(
             oldDeleteEblanApplicationInfos = oldDeleteEblanApplicationInfos,
         )
 
         updateEblanShortcutConfigs(newEblanShortcutConfigs = newEblanShortcutConfigs)
 
-        updateApplicationInfoGridItems(
-            eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-            applicationInfoGridItemRepository = applicationInfoGridItemRepository,
-        )
+        launcherAppsUtil.updateApplicationInfoGridItems()
 
         insertApplicationInfoGridItems(
             eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
@@ -217,13 +196,14 @@ class SyncDataUseCase @Inject constructor(
     ) {
         if (!homeSettings.addNewAppsToHomeScreen || experimentalSettings.firstLaunch) return
 
-        val gridItems = (gridRepository.gridItems.first() + getFolderGridItemsUseCase().first()).toMutableList()
+        val gridItems =
+            (gridRepository.gridItems.first() + getFolderGridItemsUseCase().first()).toMutableList()
 
         val newlyInstalledSyncEblanApplicationInfos =
             newSyncEblanApplicationInfos - oldSyncEblanApplicationInfos.toSet()
 
         newlyInstalledSyncEblanApplicationInfos.forEach { syncEblanApplicationInfo ->
-            addNewApplicationToHomeScreen(
+            launcherAppsUtil.addNewApplicationToHomeScreen(
                 gridItems = gridItems,
                 componentName = syncEblanApplicationInfo.componentName,
                 packageName = syncEblanApplicationInfo.packageName,
@@ -275,21 +255,19 @@ class SyncDataUseCase @Inject constructor(
             appWidgetManagerAppWidgetProviderInfos.map { appWidgetManagerAppWidgetProviderInfo ->
                 currentCoroutineContext().ensureActive()
 
-                appWidgetManagerAppWidgetProviderInfo.toEblanAppWidgetProviderInfo(
-                    fileManager = fileManager,
-                    packageManagerWrapper = packageManagerWrapper,
-                    iconKeyGenerator = iconKeyGenerator,
+                launcherAppsUtil.toEblanAppWidgetProviderInfo(
+                    appWidgetManagerAppWidgetProviderInfo = appWidgetManagerAppWidgetProviderInfo,
                 )
             }
 
         val newDeleteEblanAppWidgetProviderInfos =
             newEblanAppWidgetProviderInfos.map { eblanAppWidgetProviderInfo ->
-                eblanAppWidgetProviderInfo.toDeleteEblanAppWidgetProviderInfo()
+                launcherAppsUtil.toDeleteEblanAppWidgetProviderInfo(eblanAppWidgetProviderInfo = eblanAppWidgetProviderInfo)
             }.toSet()
 
         val oldDeleteEblanAppWidgetProviderInfos =
             oldEblanAppWidgetProviderInfos.map { eblanAppWidgetProviderInfo ->
-                eblanAppWidgetProviderInfo.toDeleteEblanAppWidgetProviderInfo()
+                launcherAppsUtil.toDeleteEblanAppWidgetProviderInfo(eblanAppWidgetProviderInfo = eblanAppWidgetProviderInfo)
             }.filter { deleteEblanAppWidgetProviderInfo ->
                 deleteEblanAppWidgetProviderInfo !in newDeleteEblanAppWidgetProviderInfos
             }
@@ -302,19 +280,11 @@ class SyncDataUseCase @Inject constructor(
             deleteEblanAppWidgetProviderInfos = oldDeleteEblanAppWidgetProviderInfos,
         )
 
-        deleteEblanAppWidgetProviderInfoIcons(
-            eblanApplicationInfos = eblanApplicationInfoRepository.getEblanApplicationInfos(),
-            eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
+        launcherAppsUtil.deleteEblanAppWidgetProviderInfoIcons(
             oldDeleteEblanAppWidgetProviderInfos = oldDeleteEblanAppWidgetProviderInfos,
         )
 
-        updateWidgetGridItems(
-            eblanAppWidgetProviderInfos = eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos(),
-            fileManager = fileManager,
-            packageManagerWrapper = packageManagerWrapper,
-            widgetGridItemRepository = widgetGridItemRepository,
-            iconKeyGenerator = iconKeyGenerator,
-        )
+        launcherAppsUtil.updateWidgetGridItems()
     }
 
     private suspend fun updateEblanLauncherShortcutInfos() {
@@ -340,15 +310,15 @@ class SyncDataUseCase @Inject constructor(
         val newEblanShortcutInfos = launcherAppsShortcutInfos.map { launcherAppsShortcutInfo ->
             currentCoroutineContext().ensureActive()
 
-            launcherAppsShortcutInfo.toEblanShortcutInfo()
+            launcherAppsUtil.toEblanShortcutInfo(launcherAppsShortcutInfo = launcherAppsShortcutInfo)
         }
 
         val newDeleteEblanShortcutInfos = newEblanShortcutInfos.map { eblanShortcutInfo ->
-            eblanShortcutInfo.toDeleteEblanShortcutInfo()
+            launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
         }.toSet()
 
         val oldDeleteEblanShortcutInfos = oldEblanShortcutInfos.map { eblanShortcutInfo ->
-            eblanShortcutInfo.toDeleteEblanShortcutInfo()
+            launcherAppsUtil.toDeleteEblanShortcutInfo(eblanShortcutInfo = eblanShortcutInfo)
         }.filter { deleteEblanShortcutInfo ->
             deleteEblanShortcutInfo !in newDeleteEblanShortcutInfos
         }
@@ -361,15 +331,9 @@ class SyncDataUseCase @Inject constructor(
             deleteEblanShortcutInfos = oldDeleteEblanShortcutInfos,
         )
 
-        deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
+        launcherAppsUtil.deleteEblanShortInfoIcons(oldDeleteEblanShortcutInfos = oldDeleteEblanShortcutInfos)
 
-        updateShortcutInfoGridItems(
-            eblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos(),
-            shortcutInfoGridItemRepository = shortcutInfoGridItemRepository,
-            fileManager = fileManager,
-            packageManagerWrapper = packageManagerWrapper,
-            iconKeyGenerator = iconKeyGenerator,
-        )
+        launcherAppsUtil.updateShortcutInfoGridItems()
     }
 
     private suspend fun updateEblanShortcutConfigs(
@@ -379,11 +343,11 @@ class SyncDataUseCase @Inject constructor(
 
         if (oldEblanShortcutConfigs.toSet() != newEblanShortcutConfigs) {
             val newDeleteEblanShortcutConfigs = newEblanShortcutConfigs.map { eblanShortcutConfig ->
-                eblanShortcutConfig.toDeleteEblanShortcutConfig()
+                launcherAppsUtil.toDeleteEblanShortcutConfig(eblanShortcutConfig = eblanShortcutConfig)
             }.toSet()
 
             val oldDeleteEblanShortcutConfigs = oldEblanShortcutConfigs.map { eblanShortcutConfig ->
-                eblanShortcutConfig.toDeleteEblanShortcutConfig()
+                launcherAppsUtil.toDeleteEblanShortcutConfig(eblanShortcutConfig = eblanShortcutConfig)
             }.filter { deleteEblanShortcutConfig ->
                 deleteEblanShortcutConfig !in newDeleteEblanShortcutConfigs
             }
@@ -396,15 +360,9 @@ class SyncDataUseCase @Inject constructor(
                 deleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs,
             )
 
-            deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs)
+            launcherAppsUtil.deleteEblanShortcutConfigIcons(oldDeleteEblanShortcutConfigs = oldDeleteEblanShortcutConfigs)
 
-            updateShortcutConfigGridItems(
-                eblanShortcutConfigs = eblanShortcutConfigRepository.getEblanShortcutConfigs(),
-                shortcutConfigGridItemRepository = shortcutConfigGridItemRepository,
-                fileManager = fileManager,
-                packageManagerWrapper = packageManagerWrapper,
-                iconKeyGenerator = iconKeyGenerator,
-            )
+            launcherAppsUtil.updateShortcutConfigGridItems()
         }
     }
 


### PR DESCRIPTION
Closes #757 

- Created `LauncherAppsUtil` to centralize helper methods for converting domain models (`EblanShortcutConfig`, `EblanAppWidgetProviderInfo`, etc.), managing icon deletions, and updating grid items.
- Migrated several top-level extension functions and internal helpers from `LauncherAppsUtil.kt` into the new `LauncherAppsUtil` class with constructor-injected dependencies.
- Created `IconPackInfoUseCaseUtil` to encapsulate icon pack update and caching logic, replacing standalone internal functions.
- Updated `SyncDataUseCase`, `ChangePackageUseCase`, `AddPackageUseCase`, `ChangeShortcutsUseCase`, and `UpdateIconPackInfosUseCase` to use the new utility classes, significantly reducing their direct dependency footprint.
- Simplified method signatures in use cases by delegating complex mapping and repository interactions to the centralized utility classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating icon pack management operations into dedicated utility classes.
  * Streamlined launcher app handling by centralizing utility functions and reducing direct dependencies across multiple use cases.
  * Enhanced code maintainability through better separation of concerns in dependency injection patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->