### PR TITLE
Refactored folder item management and persistence logic:

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
@@ -130,4 +130,8 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(priv
 
         applicationInfoGridItemDao.updateApplicationInfoGridItemEntities(entities = entities)
     }
+
+    override suspend fun upsertApplicationInfoGridItem(applicationInfoGridItem: ApplicationInfoGridItem) {
+        applicationInfoGridItemDao.upsertApplicationInfoGridItemEntity(entity = applicationInfoGridItem.asEntity())
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
@@ -74,4 +74,12 @@ internal class DefaultFolderGridItemRepository @Inject constructor(private val f
 
         folderGridItemDao.updateFolderGridItemEntities(entities = entities)
     }
+
+    override suspend fun insertFolderGridItems(folderGridItems: List<FolderGridItem>) {
+        val entities = folderGridItems.map { folderGridItem ->
+            folderGridItem.asEntity()
+        }
+
+        folderGridItemDao.insertFolderGridItemEntities(entities = entities)
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
@@ -82,4 +82,8 @@ internal class DefaultFolderGridItemRepository @Inject constructor(private val f
 
         folderGridItemDao.insertFolderGridItemEntities(entities = entities)
     }
+
+    override suspend fun upsertFolderGridItem(folderGridItem: FolderGridItem) {
+        folderGridItemDao.upsertFolderGridItemEntity(entity = folderGridItem.asEntity())
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -94,6 +94,8 @@ internal class DefaultGridRepository @Inject constructor(
                 folderGridItemRepository.insertFolderGridItem(
                     folderGridItem = gridItem.asFolderGridItem(data = data),
                 )
+
+                insertGridItems(gridItems = data.gridItems)
             }
 
             is GridItemData.ShortcutInfo -> {
@@ -452,5 +454,67 @@ internal class DefaultGridRepository @Inject constructor(
                 )
             }
         }
+    }
+
+    private suspend fun insertGridItems(gridItems: List<GridItem>) {
+        val applicationInfoGridItems = mutableListOf<ApplicationInfoGridItem>()
+
+        val widgetGridItems = mutableListOf<WidgetGridItem>()
+
+        val shortcutInfoGridItems = mutableListOf<ShortcutInfoGridItem>()
+
+        val folderGridItems = mutableListOf<FolderGridItem>()
+
+        val shortcutConfigGridItems = mutableListOf<ShortcutConfigGridItem>()
+
+        gridItems.forEach { gridItem ->
+            when (val data = gridItem.data) {
+                is GridItemData.ApplicationInfo -> {
+                    applicationInfoGridItems.add(
+                        gridItem.asApplicationInfoGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.Folder -> {
+                    folderGridItems.add(
+                        gridItem.asFolderGridItem(data = data),
+                    )
+
+                    insertGridItems(gridItems = data.gridItems)
+                }
+
+                is GridItemData.Widget -> {
+                    widgetGridItems.add(
+                        gridItem.asWidgetGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.ShortcutInfo -> {
+                    shortcutInfoGridItems.add(
+                        gridItem.asShortcutInfoGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.ShortcutConfig -> {
+                    shortcutConfigGridItems.add(
+                        gridItem.asShortcutConfigGridItem(data = data),
+                    )
+                }
+            }
+        }
+
+        applicationInfoGridItemRepository.insertApplicationInfoGridItems(
+            applicationInfoGridItems = applicationInfoGridItems,
+        )
+
+        widgetGridItemRepository.insertWidgetGridItems(widgetGridItems = widgetGridItems)
+
+        shortcutInfoGridItemRepository.insertShortcutInfoGridItems(shortcutInfoGridItems = shortcutInfoGridItems)
+
+        folderGridItemRepository.insertFolderGridItems(folderGridItems = folderGridItems)
+
+        shortcutConfigGridItemRepository.insertShortcutConfigGridItems(
+            shortcutConfigGridItems = shortcutConfigGridItems,
+        )
     }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -128,6 +128,8 @@ internal class DefaultGridRepository @Inject constructor(
                 folderGridItemRepository.updateFolderGridItem(
                     folderGridItem = gridItem.asFolderGridItem(data = data),
                 )
+
+                updateGridItems(gridItems = data.gridItems)
             }
 
             is GridItemData.ShortcutInfo -> {
@@ -251,6 +253,8 @@ internal class DefaultGridRepository @Inject constructor(
                     folderGridItems.add(
                         gridItem.asFolderGridItem(data = data),
                     )
+
+                    updateGridItems(gridItems = data.gridItems)
                 }
 
                 is GridItemData.Widget -> {
@@ -309,6 +313,8 @@ internal class DefaultGridRepository @Inject constructor(
                     folderGridItems.add(
                         gridItem.asFolderGridItem(data = data),
                     )
+
+                    upsertGridItems(gridItems = data.gridItems)
                 }
 
                 is GridItemData.Widget -> {

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -95,7 +95,7 @@ internal class DefaultGridRepository @Inject constructor(
                     folderGridItem = gridItem.asFolderGridItem(data = data),
                 )
 
-                insertGridItems(gridItems = data.gridItems)
+                insertFolderGridItems(gridItems = data.gridItems)
             }
 
             is GridItemData.ShortcutInfo -> {
@@ -456,7 +456,43 @@ internal class DefaultGridRepository @Inject constructor(
         }
     }
 
-    private suspend fun insertGridItems(gridItems: List<GridItem>) {
+    override suspend fun upsertGridItem(gridItem: GridItem) {
+        when (val data = gridItem.data) {
+            is GridItemData.ApplicationInfo -> {
+                applicationInfoGridItemRepository.upsertApplicationInfoGridItem(
+                    applicationInfoGridItem = gridItem.asApplicationInfoGridItem(data = data),
+                )
+            }
+
+            is GridItemData.Folder -> {
+                folderGridItemRepository.upsertFolderGridItem(
+                    folderGridItem = gridItem.asFolderGridItem(data = data),
+                )
+
+                upsertFolderGridItems(gridItems = data.gridItems)
+            }
+
+            is GridItemData.ShortcutInfo -> {
+                shortcutInfoGridItemRepository.upsertShortcutInfoGridItem(
+                    shortcutInfoGridItem = gridItem.asShortcutInfoGridItem(data = data),
+                )
+            }
+
+            is GridItemData.Widget -> {
+                widgetGridItemRepository.upsertWidgetGridItem(
+                    widgetGridItem = gridItem.asWidgetGridItem(data = data),
+                )
+            }
+
+            is GridItemData.ShortcutConfig -> {
+                shortcutConfigGridItemRepository.upsertShortcutConfigGridItem(
+                    shortcutConfigGridItem = gridItem.asShortcutConfigGridItem(data = data),
+                )
+            }
+        }
+    }
+
+    private suspend fun insertFolderGridItems(gridItems: List<GridItem>) {
         val applicationInfoGridItems = mutableListOf<ApplicationInfoGridItem>()
 
         val widgetGridItems = mutableListOf<WidgetGridItem>()
@@ -480,7 +516,7 @@ internal class DefaultGridRepository @Inject constructor(
                         gridItem.asFolderGridItem(data = data),
                     )
 
-                    insertGridItems(gridItems = data.gridItems)
+                    insertFolderGridItems(gridItems = data.gridItems)
                 }
 
                 is GridItemData.Widget -> {
@@ -514,6 +550,68 @@ internal class DefaultGridRepository @Inject constructor(
         folderGridItemRepository.insertFolderGridItems(folderGridItems = folderGridItems)
 
         shortcutConfigGridItemRepository.insertShortcutConfigGridItems(
+            shortcutConfigGridItems = shortcutConfigGridItems,
+        )
+    }
+
+    private suspend fun upsertFolderGridItems(gridItems: List<GridItem>) {
+        val applicationInfoGridItems = mutableListOf<ApplicationInfoGridItem>()
+
+        val widgetGridItems = mutableListOf<WidgetGridItem>()
+
+        val shortcutInfoGridItems = mutableListOf<ShortcutInfoGridItem>()
+
+        val folderGridItems = mutableListOf<FolderGridItem>()
+
+        val shortcutConfigGridItems = mutableListOf<ShortcutConfigGridItem>()
+
+        gridItems.forEach { gridItem ->
+            when (val data = gridItem.data) {
+                is GridItemData.ApplicationInfo -> {
+                    applicationInfoGridItems.add(
+                        gridItem.asApplicationInfoGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.Folder -> {
+                    folderGridItems.add(
+                        gridItem.asFolderGridItem(data = data),
+                    )
+
+                    insertFolderGridItems(gridItems = data.gridItems)
+                }
+
+                is GridItemData.Widget -> {
+                    widgetGridItems.add(
+                        gridItem.asWidgetGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.ShortcutInfo -> {
+                    shortcutInfoGridItems.add(
+                        gridItem.asShortcutInfoGridItem(data = data),
+                    )
+                }
+
+                is GridItemData.ShortcutConfig -> {
+                    shortcutConfigGridItems.add(
+                        gridItem.asShortcutConfigGridItem(data = data),
+                    )
+                }
+            }
+        }
+
+        applicationInfoGridItemRepository.upsertApplicationInfoGridItems(
+            applicationInfoGridItems = applicationInfoGridItems,
+        )
+
+        widgetGridItemRepository.upsertWidgetGridItems(widgetGridItems = widgetGridItems)
+
+        shortcutInfoGridItemRepository.upsertShortcutInfoGridItems(shortcutInfoGridItems = shortcutInfoGridItems)
+
+        folderGridItemRepository.upsertFolderGridItems(folderGridItems = folderGridItems)
+
+        shortcutConfigGridItemRepository.upsertShortcutConfigGridItems(
             shortcutConfigGridItems = shortcutConfigGridItems,
         )
     }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
@@ -133,4 +133,8 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
 
         shortcutConfigGridItemDao.insertShortcutConfigGridItemEntities(entities = entities)
     }
+
+    override suspend fun upsertShortcutConfigGridItem(shortcutConfigGridItem: ShortcutConfigGridItem) {
+        shortcutConfigGridItemDao.upsertShortcutConfigGridItemEntity(entity = shortcutConfigGridItem.asEntity())
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
@@ -125,4 +125,12 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
 
         shortcutConfigGridItemDao.updateShortcutConfigGridItemEntities(entities = entities)
     }
+
+    override suspend fun insertShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>) {
+        val entities = shortcutConfigGridItems.map { shortcutConfigGridItem ->
+            shortcutConfigGridItem.asEntity()
+        }
+
+        shortcutConfigGridItemDao.insertShortcutConfigGridItemEntities(entities = entities)
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
@@ -128,4 +128,8 @@ internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private
 
         shortcutInfoGridItemDao.insertShortcutInfoGridItemEntities(entities = entities)
     }
+
+    override suspend fun upsertShortcutInfoGridItem(shortcutInfoGridItem: ShortcutInfoGridItem) {
+        shortcutInfoGridItemDao.upsertShortcutInfoGridItemEntity(entity = shortcutInfoGridItem.asEntity())
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
@@ -120,4 +120,12 @@ internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private
 
         shortcutInfoGridItemDao.updateShortcutInfoGridItemEntities(entities = entities)
     }
+
+    override suspend fun insertShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>) {
+        val entities = shortcutInfoGridItems.map { shortcutInfoGridItem ->
+            shortcutInfoGridItem.asEntity()
+        }
+
+        shortcutInfoGridItemDao.insertShortcutInfoGridItemEntities(entities = entities)
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
@@ -104,4 +104,8 @@ internal class DefaultWidgetGridItemRepository @Inject constructor(private val w
 
         widgetGridItemDao.insertWidgetGridItemEntities(entities = entities)
     }
+
+    override suspend fun upsertWidgetGridItem(widgetGridItem: WidgetGridItem) {
+        widgetGridItemDao.upsertWidgetGridItemEntity(entity = widgetGridItem.asEntity())
+    }
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
@@ -96,4 +96,12 @@ internal class DefaultWidgetGridItemRepository @Inject constructor(private val w
 
         widgetGridItemDao.updateWidgetGridItemEntities(entities = entities)
     }
+
+    override suspend fun insertWidgetGridItems(widgetGridItems: List<WidgetGridItem>) {
+        val entities = widgetGridItems.map { widgetGridItem ->
+            widgetGridItem.asEntity()
+        }
+
+        widgetGridItemDao.insertWidgetGridItemEntities(entities = entities)
+    }
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ApplicationInfoGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ApplicationInfoGridItemDao.kt
@@ -70,4 +70,7 @@ interface ApplicationInfoGridItemDao {
 
     @Update
     suspend fun updateApplicationInfoGridItemEntities(entities: List<ApplicationInfoGridItemEntity>)
+
+    @Upsert
+    suspend fun upsertApplicationInfoGridItemEntity(entity: ApplicationInfoGridItemEntity)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
@@ -63,4 +63,7 @@ interface FolderGridItemDao {
 
     @Insert
     suspend fun insertFolderGridItemEntities(entities: List<FolderGridItemEntity>)
+
+    @Upsert
+    suspend fun upsertFolderGridItemEntity(entity: FolderGridItemEntity)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
@@ -60,4 +60,7 @@ interface FolderGridItemDao {
 
     @Update
     suspend fun updateFolderGridItemEntities(entities: List<FolderGridItemEntity>)
+
+    @Insert
+    suspend fun insertFolderGridItemEntities(entities: List<FolderGridItemEntity>)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutConfigGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutConfigGridItemDao.kt
@@ -67,4 +67,7 @@ interface ShortcutConfigGridItemDao {
 
     @Update
     suspend fun updateShortcutConfigGridItemEntities(entities: List<ShortcutConfigGridItemEntity>)
+
+    @Insert
+    suspend fun insertShortcutConfigGridItemEntities(entities: List<ShortcutConfigGridItemEntity>)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutConfigGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutConfigGridItemDao.kt
@@ -70,4 +70,7 @@ interface ShortcutConfigGridItemDao {
 
     @Insert
     suspend fun insertShortcutConfigGridItemEntities(entities: List<ShortcutConfigGridItemEntity>)
+
+    @Upsert
+    suspend fun upsertShortcutConfigGridItemEntity(entity: ShortcutConfigGridItemEntity)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutInfoGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutInfoGridItemDao.kt
@@ -70,4 +70,7 @@ interface ShortcutInfoGridItemDao {
 
     @Insert
     suspend fun insertShortcutInfoGridItemEntities(entities: List<ShortcutInfoGridItemEntity>)
+
+    @Upsert
+    suspend fun upsertShortcutInfoGridItemEntity(entity: ShortcutInfoGridItemEntity)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutInfoGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/ShortcutInfoGridItemDao.kt
@@ -67,4 +67,7 @@ interface ShortcutInfoGridItemDao {
 
     @Update
     suspend fun updateShortcutInfoGridItemEntities(entities: List<ShortcutInfoGridItemEntity>)
+
+    @Insert
+    suspend fun insertShortcutInfoGridItemEntities(entities: List<ShortcutInfoGridItemEntity>)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/WidgetGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/WidgetGridItemDao.kt
@@ -61,4 +61,7 @@ interface WidgetGridItemDao {
 
     @Update
     suspend fun updateWidgetGridItemEntities(entities: List<WidgetGridItemEntity>)
+
+    @Insert
+    suspend fun insertWidgetGridItemEntities(entities: List<WidgetGridItemEntity>)
 }

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/WidgetGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/WidgetGridItemDao.kt
@@ -64,4 +64,7 @@ interface WidgetGridItemDao {
 
     @Insert
     suspend fun insertWidgetGridItemEntities(entities: List<WidgetGridItemEntity>)
+
+    @Upsert
+    suspend fun upsertWidgetGridItemEntity(entity: WidgetGridItemEntity)
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemData.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItemData.kt
@@ -75,6 +75,7 @@ sealed interface GridItemData {
         val icon: String?,
         val columns: Int,
         val rows: Int,
+        val maxIndex: Int,
     ) : GridItemData
 
     data class ShortcutConfig(

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ApplicationInfoGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ApplicationInfoGridItemRepository.kt
@@ -58,4 +58,6 @@ interface ApplicationInfoGridItemRepository {
     suspend fun insertApplicationInfoGridItem(applicationInfoGridItem: ApplicationInfoGridItem)
 
     suspend fun updateApplicationInfoGridItems(applicationInfoGridItems: List<ApplicationInfoGridItem>)
+
+    suspend fun upsertApplicationInfoGridItem(applicationInfoGridItem: ApplicationInfoGridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
@@ -37,4 +37,6 @@ interface FolderGridItemRepository {
     suspend fun insertFolderGridItem(folderGridItem: FolderGridItem)
 
     suspend fun updateFolderGridItems(folderGridItems: List<FolderGridItem>)
+
+    suspend fun insertFolderGridItems(folderGridItems: List<FolderGridItem>)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
@@ -39,4 +39,6 @@ interface FolderGridItemRepository {
     suspend fun updateFolderGridItems(folderGridItems: List<FolderGridItem>)
 
     suspend fun insertFolderGridItems(folderGridItems: List<FolderGridItem>)
+
+    suspend fun upsertFolderGridItem(folderGridItem: FolderGridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/GridRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/GridRepository.kt
@@ -42,4 +42,6 @@ interface GridRepository {
     suspend fun deleteGridItems(gridItems: List<GridItem>)
 
     suspend fun deleteGridItem(gridItem: GridItem)
+
+    suspend fun upsertGridItem(gridItem: GridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
@@ -58,4 +58,6 @@ interface ShortcutConfigGridItemRepository {
     suspend fun updateShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>)
 
     suspend fun insertShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>)
+
+    suspend fun upsertShortcutConfigGridItem(shortcutConfigGridItem: ShortcutConfigGridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
@@ -56,4 +56,6 @@ interface ShortcutConfigGridItemRepository {
     suspend fun insertShortcutConfigGridItem(shortcutConfigGridItem: ShortcutConfigGridItem)
 
     suspend fun updateShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>)
+
+    suspend fun insertShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
@@ -58,4 +58,6 @@ interface ShortcutInfoGridItemRepository {
     suspend fun updateShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>)
 
     suspend fun insertShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>)
+
+    suspend fun upsertShortcutInfoGridItem(shortcutInfoGridItem: ShortcutInfoGridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
@@ -56,4 +56,6 @@ interface ShortcutInfoGridItemRepository {
     suspend fun insertShortcutInfoGridItem(shortcutInfoGridItem: ShortcutInfoGridItem)
 
     suspend fun updateShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>)
+
+    suspend fun insertShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/WidgetGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/WidgetGridItemRepository.kt
@@ -49,4 +49,6 @@ interface WidgetGridItemRepository {
     suspend fun updateWidgetGridItems(widgetGridItems: List<WidgetGridItem>)
 
     suspend fun insertWidgetGridItems(widgetGridItems: List<WidgetGridItem>)
+
+    suspend fun upsertWidgetGridItem(widgetGridItem: WidgetGridItem)
 }

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/WidgetGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/WidgetGridItemRepository.kt
@@ -47,4 +47,6 @@ interface WidgetGridItemRepository {
     suspend fun insertWidgetGridItem(widgetGridItem: WidgetGridItem)
 
     suspend fun updateWidgetGridItems(widgetGridItems: List<WidgetGridItem>)
+
+    suspend fun insertWidgetGridItems(widgetGridItems: List<WidgetGridItem>)
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -66,6 +66,15 @@ internal suspend fun FolderGridItemWrapper.asGridItem(): GridItem {
 
     val (columns, rows) = getGridDimension(count = firstPageGridItems.size)
 
+    val maxIndex = gridItems.maxOfOrNull { folderGridItem ->
+        when (val data = folderGridItem.data) {
+            is GridItemData.ApplicationInfo -> data.index + 1
+            is GridItemData.ShortcutConfig -> data.index + 1
+            is GridItemData.ShortcutInfo -> data.index + 1
+            else -> error("Unsupported Folder GridItem ")
+        }
+    } ?: 0
+
     val data = Folder(
         id = folderGridItem.id,
         label = folderGridItem.label,
@@ -75,6 +84,7 @@ internal suspend fun FolderGridItemWrapper.asGridItem(): GridItem {
         icon = folderGridItem.icon,
         columns = columns,
         rows = rows,
+        maxIndex = maxIndex,
     )
 
     return GridItem(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -74,7 +74,7 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                 is GridItemData.ApplicationInfo -> folderData.index + 1
                 is GridItemData.ShortcutConfig -> folderData.index + 1
                 is GridItemData.ShortcutInfo -> folderData.index + 1
-                else -> return
+                else -> error("Unsupported folder creation")
             }
         } ?: 0
 
@@ -94,7 +94,7 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                 folderId = data.id,
             )
 
-            else -> return
+            else -> error("Unsupported folder creation")
         }
 
         gridRepository.updateGridItem(gridItem = movingGridItem.copy(data = newData))
@@ -129,9 +129,7 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                 )
             }
 
-            else -> {
-                return
-            }
+            else -> error("Unsupported folder creation")
         }
 
         val movingData = when (val data = movingGridItem.data) {
@@ -156,9 +154,7 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                 )
             }
 
-            else -> {
-                return
-            }
+            else -> error("Unsupported folder creation")
         }
 
         val newConflictingGridItem = conflictingGridItem.copy(data = conflictingData)
@@ -170,7 +166,7 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
             newMovingGridItem,
         )
 
-        gridRepository.insertGridItem(
+        gridRepository.upsertGridItem(
             gridItem = conflictingGridItem.copy(
                 id = id,
                 data = GridItemData.Folder(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -165,10 +165,6 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
 
         val newMovingGridItem = movingGridItem.copy(data = movingData)
 
-        gridRepository.updateGridItem(gridItem = newConflictingGridItem)
-
-        gridRepository.updateGridItem(gridItem = newMovingGridItem)
-
         val folderGridItems = listOf(
             newConflictingGridItem,
             newMovingGridItem,
@@ -179,13 +175,14 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                 id = id,
                 data = GridItemData.Folder(
                     id = id,
-                    label = "Unknown",
+                    label = "New Folder",
                     gridItems = folderGridItems,
                     gridItemsByPage = mapOf(0 to folderGridItems),
                     previewGridItemsByPage = folderGridItems,
                     icon = null,
                     columns = 1,
                     rows = 2,
+                    maxIndex = 1,
                 ),
             ),
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -46,7 +46,6 @@ import com.eblan.launcher.domain.usecase.application.GetEblanShortcutConfigsByLa
 import com.eblan.launcher.domain.usecase.application.GetEblanShortcutInfosUseCase
 import com.eblan.launcher.domain.usecase.application.UpdateEblanApplicationInfosIndexesUseCase
 import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsByIdUseCase
-import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveFolderGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.ResizeGridItemUseCase
@@ -107,7 +106,6 @@ internal class HomeViewModel @Inject constructor(
     getFolderGridItemsByIdUseCase: GetFolderGridItemsByIdUseCase,
     private val moveFolderGridItemUseCase: MoveFolderGridItemUseCase,
     private val iconKeyGenerator: IconKeyGenerator,
-    private val getFolderGridItemsUseCase: GetFolderGridItemsUseCase,
 ) : ViewModel() {
     val homeUiState = getHomeDataUseCase().map(HomeUiState::Success).stateIn(
         scope = viewModelScope,
@@ -356,8 +354,6 @@ internal class HomeViewModel @Inject constructor(
 
             updateGridItemsAfterMoveUseCase(moveGridItemResult = moveGridItemResult)
 
-            gridRepository.getGridItems().plus(getFolderGridItemsUseCase())
-
             _isVisibleOverlay.update {
                 false
             }
@@ -602,8 +598,6 @@ internal class HomeViewModel @Inject constructor(
     fun resetGridAfterMoveFolder() {
         viewModelScope.launch {
             moveGridItemJob?.cancelAndJoin()
-
-            getFolderGridItemsUseCase()
 
             _isVisibleOverlay.update {
                 false

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -577,28 +577,19 @@ internal suspend fun handleConflictingGridItem(
 
     val movingGridItem = moveGridItemResult.movingGridItem
 
-    val index = conflictingData.gridItems.maxOfOrNull { folderGridItem ->
-        when (val data = folderGridItem.data) {
-            is GridItemData.ApplicationInfo -> data.index + 1
-            is GridItemData.ShortcutConfig -> data.index + 1
-            is GridItemData.ShortcutInfo -> data.index + 1
-            else -> error("Unsupported Folder GridItem ")
-        }
-    } ?: 0
-
     val movingData = when (val data = movingGridItem.data) {
         is GridItemData.ApplicationInfo -> data.copy(
-            index = index,
+            index = conflictingData.maxIndex,
             folderId = conflictingData.id,
         )
 
         is GridItemData.ShortcutConfig -> data.copy(
-            index = index,
+            index = conflictingData.maxIndex,
             folderId = conflictingData.id,
         )
 
         is GridItemData.ShortcutInfo -> data.copy(
-            index = index,
+            index = conflictingData.maxIndex,
             folderId = conflictingData.id,
         )
 


### PR DESCRIPTION
- Added `maxIndex` to `GridItemData.Folder` to track and provide the next available index for items contained within a folder.
- Updated `DefaultGridRepository` to ensure that children items within a folder are automatically updated or upserted whenever the parent folder is modified.
- Centralized folder index calculation in `GridUtil.kt` by implementing a helper to determine the `maxIndex` from existing folder contents.
- Simplified `DragGridItemHelper` by leveraging the new `maxIndex` property when moving items into existing folders, removing redundant local index calculations.
- Improved the folder creation flow in `UpdateGridItemsAfterMoveUseCase` by providing a default "New Folder" label and initializing the `maxIndex`.
- Removed unnecessary individual repository updates in `UpdateGridItemsAfterMoveUseCase` in favor of the unified folder update logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better handling of items inside nested folders; improved save/upsert and bulk-save support for grid items.

* **Bug Fixes**
  * Simplified and more reliable conflict resolution when moving items into folders; new folders now appear as "New Folder".
  * Harder failures now surfaced instead of silently ignoring unsupported cases, improving consistency.

* **Chores**
  * Cleaned up project configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->