### PR TITLE
Refactored action controls in `EditPageScreen` to use an expandable Floating Action Button (FAB)

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoItem.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -151,7 +150,7 @@ internal fun SharedTransitionScope.EblanApplicationInfoItem(
         getVerticalArrangement(verticalArrangement = appDrawerSettings.gridItemSettings.verticalArrangement)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoItem.kt
@@ -53,13 +53,13 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.sp
@@ -129,6 +129,8 @@ internal fun SharedTransitionScope.EblanApplicationInfoItem(
 
     val launcherApps = LocalLauncherApps.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val textColor = getSystemTextColor(
@@ -149,7 +151,7 @@ internal fun SharedTransitionScope.EblanApplicationInfoItem(
         getVerticalArrangement(verticalArrangement = appDrawerSettings.gridItemSettings.verticalArrangement)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
@@ -38,9 +38,9 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.EblanAppWidgetProviderInfo
@@ -98,8 +98,10 @@ internal fun ApplicationInfoPopup(
 
     val launcherApps = LocalLauncherApps.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -239,10 +241,12 @@ internal fun PrivateApplicationInfoPopup(
 
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val launcherApps = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -101,7 +100,7 @@ internal fun ApplicationInfoPopup(
     val layoutDirection = LocalLayoutDirection.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -246,7 +245,7 @@ internal fun PrivateApplicationInfoPopup(
     val launcherApps = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -56,13 +56,13 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.sp
@@ -122,11 +122,9 @@ internal fun LazyGridScope.privateSpace(
                 eblanApplicationInfo = eblanApplicationInfo,
                 iconPackFilePaths = iconPackFilePaths,
                 paddingValues = paddingValues,
-                onDismiss = onDismiss,
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdatePopupMenu = onUpdatePopupMenu,
                 onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
-                onScrollToItem = onScrollToItem,
             )
         }
     }
@@ -232,20 +230,20 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
     eblanApplicationInfo: EblanApplicationInfo,
     iconPackFilePaths: Map<String, String>,
     paddingValues: PaddingValues,
-    onDismiss: () -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
 ) {
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
     var intSize by remember { mutableStateOf(IntSize.Zero) }
 
     val density = LocalDensity.current
+
+    val layoutDirection = LocalLayoutDirection.current
 
     val launcherApps = LocalLauncherApps.current
 
@@ -271,7 +269,7 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
         getVerticalArrangement(verticalArrangement = appDrawerSettings.gridItemSettings.verticalArrangement)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -93,7 +92,6 @@ internal fun LazyGridScope.privateSpace(
     paddingValues: PaddingValues,
     privateEblanApplicationInfos: List<EblanApplicationInfo>,
     privateEblanUser: EblanUser?,
-    onDismiss: () -> Unit,
     onUpdateIsQuietModeEnabled: (Boolean) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
@@ -101,7 +99,6 @@ internal fun LazyGridScope.privateSpace(
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
 ) {
     if (privateEblanUser == null || privateEblanUser.isPrivateSpaceEntryPointHidden) return
 
@@ -269,7 +266,7 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
         getVerticalArrangement(verticalArrangement = appDrawerSettings.gridItemSettings.verticalArrangement)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -50,9 +50,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.AppDrawerSettings
@@ -129,6 +129,10 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
 ) {
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
+    val launcherApps = LocalLauncherApps.current
+
     var showPopupApplicationMenu by remember { mutableStateOf(false) }
 
     var showPrivatePopupApplicationMenu by remember { mutableStateOf(false) }
@@ -137,10 +141,8 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
 
     var popupIntSize by remember { mutableStateOf(IntSize.Zero) }
 
-    val launcherApps = LocalLauncherApps.current
-
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -253,9 +255,6 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
                     selectedEblanApplicationInfo = eblanApplicationInfo
                 },
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
-                onScrollToItem = {
-                    horizontalPagerState.scrollToPage(0)
-                },
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
         }
@@ -377,7 +376,6 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
     onVerticalDrag: (Float) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
     val userManager = LocalUserManager.current
@@ -450,7 +448,6 @@ private fun SharedTransitionScope.EblanApplicationInfosPage(
                 onVerticalDrag = onVerticalDrag,
                 onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
-                onScrollToItem = onScrollToItem,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
 
@@ -510,7 +507,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
     onVerticalDrag: (Float) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
     HorizontalAppDrawerGridLayout(
@@ -564,11 +560,9 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         eblanApplicationInfo = eblanApplicationInfo,
                         iconPackFilePaths = iconPackFilePaths,
                         paddingValues = paddingValues,
-                        onDismiss = onDismiss,
                         onUpdateOverlayBounds = onUpdateOverlayBounds,
                         onUpdatePopupMenu = onUpdatePrivatePopupMenu,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
-                        onScrollToItem = onScrollToItem,
                     )
                 }
             }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -142,7 +141,7 @@ internal fun SharedTransitionScope.HorizontalApplicationScreen(
     var popupIntSize by remember { mutableStateOf(IntSize.Zero) }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -76,12 +76,12 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.sp
@@ -172,6 +172,8 @@ internal fun SharedTransitionScope.ListApplicationScreen(
 ) {
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     var showPopupApplicationMenu by remember { mutableStateOf(false) }
 
     var showPrivatePopupApplicationMenu by remember { mutableStateOf(false) }
@@ -183,7 +185,7 @@ internal fun SharedTransitionScope.ListApplicationScreen(
     val launcherApps = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -234,8 +236,8 @@ internal fun SharedTransitionScope.ListApplicationScreen(
             .fillMaxSize()
             .padding(
                 top = paddingValues.calculateTopPadding(),
-                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                start = paddingValues.calculateStartPadding(layoutDirection),
+                end = paddingValues.calculateEndPadding(layoutDirection),
             ),
     ) {
         ApplicationSearchBarWithoutMenu(
@@ -678,7 +680,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         isQuietModeEnabled = isQuietModeEnabled,
                         managedProfileResult = managedProfileResult,
                         paddingValues = paddingValues,
-                        onDismiss = onDismiss,
                         privateEblanApplicationInfos = getEblanApplicationInfosByLabelAndTag.privateEblanApplicationInfos,
                         privateEblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
                         onUpdateIsQuietModeEnabled = { newIsQuiteModeEnabled ->
@@ -687,7 +688,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         onUpdateOverlayBounds = onUpdateOverlayBounds,
                         onUpdatePopupMenu = onUpdatePrivatePopupMenu,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
-                        onScrollToItem = lazyListState::scrollToItem,
                     )
                 }
 
@@ -774,6 +774,8 @@ private fun SharedTransitionScope.EblanApplicationInfoItem(
 
     val launcherApps = LocalLauncherApps.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val textColor = getSystemTextColor(
@@ -786,7 +788,7 @@ private fun SharedTransitionScope.EblanApplicationInfoItem(
     val icon = iconPackFilePaths[eblanApplicationInfo.componentName] ?: eblanApplicationInfo.icon
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -185,7 +185,7 @@ internal fun SharedTransitionScope.ListApplicationScreen(
     val launcherApps = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -788,7 +788,7 @@ private fun SharedTransitionScope.EblanApplicationInfoItem(
     val icon = iconPackFilePaths[eblanApplicationInfo.componentName] ?: eblanApplicationInfo.icon
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -161,7 +160,7 @@ private fun PrivateSpaceEblanApplicationInfoItem(
     val icon = iconPackFilePaths[eblanApplicationInfo.componentName] ?: eblanApplicationInfo.icon
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -48,12 +48,12 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.sp
@@ -82,7 +82,6 @@ internal fun LazyListScope.privateSpace(
     paddingValues: PaddingValues,
     privateEblanApplicationInfos: List<EblanApplicationInfo>,
     privateEblanUser: EblanUser?,
-    onDismiss: () -> Unit,
     onUpdateIsQuietModeEnabled: (Boolean) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
@@ -90,7 +89,6 @@ internal fun LazyListScope.privateSpace(
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
 ) {
     if (privateEblanUser == null || privateEblanUser.isPrivateSpaceEntryPointHidden) return
 
@@ -111,11 +109,9 @@ internal fun LazyListScope.privateSpace(
                 eblanApplicationInfo = eblanApplicationInfo,
                 iconPackFilePaths = iconPackFilePaths,
                 paddingValues = paddingValues,
-                onDismiss = onDismiss,
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdatePopupMenu = onUpdatePopupMenu,
                 onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
-                onScrollToItem = onScrollToItem,
             )
         }
     }
@@ -134,14 +130,12 @@ private fun PrivateSpaceEblanApplicationInfoItem(
     eblanApplicationInfo: EblanApplicationInfo,
     iconPackFilePaths: Map<String, String>,
     paddingValues: PaddingValues,
-    onDismiss: () -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
-    onScrollToItem: suspend (Int) -> Unit,
 ) {
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
@@ -152,6 +146,8 @@ private fun PrivateSpaceEblanApplicationInfoItem(
     val launcherApps = LocalLauncherApps.current
 
     val keyboardController = LocalSoftwareKeyboardController.current
+
+    val layoutDirection = LocalLayoutDirection.current
 
     val scope = rememberCoroutineScope()
 
@@ -165,7 +161,7 @@ private fun PrivateSpaceEblanApplicationInfoItem(
     val icon = iconPackFilePaths[eblanApplicationInfo.componentName] ?: eblanApplicationInfo.icon
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -61,9 +61,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.AppDrawerSettings
@@ -145,6 +145,10 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
 ) {
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
+    val launcherApps = LocalLauncherApps.current
+
     var showPopupApplicationMenu by remember { mutableStateOf(false) }
 
     var showPrivatePopupApplicationMenu by remember { mutableStateOf(false) }
@@ -153,10 +157,8 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
 
     var popupIntSize by remember { mutableStateOf(IntSize.Zero) }
 
-    val launcherApps = LocalLauncherApps.current
-
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -209,8 +211,8 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
             .fillMaxSize()
             .padding(
                 top = paddingValues.calculateTopPadding(),
-                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                start = paddingValues.calculateStartPadding(layoutDirection),
+                end = paddingValues.calculateEndPadding(layoutDirection),
             ),
     ) {
         ApplicationSearchBar(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -158,7 +158,7 @@ internal fun SharedTransitionScope.VerticalApplicationScreen(
     var popupIntSize by remember { mutableStateOf(IntSize.Zero) }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -676,7 +676,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         isQuietModeEnabled = isQuietModeEnabled,
                         managedProfileResult = managedProfileResult,
                         paddingValues = paddingValues,
-                        onDismiss = onDismiss,
                         privateEblanApplicationInfos = getEblanApplicationInfosByLabelAndTag.privateEblanApplicationInfos,
                         privateEblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
                         onUpdateIsQuietModeEnabled = { newIsQuiteModeEnabled ->
@@ -685,7 +684,6 @@ private fun SharedTransitionScope.EblanApplicationInfos(
                         onUpdateOverlayBounds = onUpdateOverlayBounds,
                         onUpdatePopupMenu = onUpdatePrivatePopupMenu,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
-                        onScrollToItem = lazyGridState::scrollToItem,
                     )
                 }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
@@ -25,12 +25,16 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -39,13 +43,15 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
@@ -56,6 +62,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
@@ -129,12 +136,6 @@ internal fun EditPageScreen(
             }
         }
 
-    val isAtTop by remember(key1 = lazyListState) {
-        derivedStateOf {
-            lazyListState.firstVisibleItemIndex == 0 && lazyListState.firstVisibleItemScrollOffset == 0
-        }
-    }
-
     val activity = LocalActivity.current as ComponentActivity
 
     val scope = rememberCoroutineScope()
@@ -156,6 +157,8 @@ internal fun EditPageScreen(
 
         Associate.Dock -> homeSettings.dockHeight.dp
     }
+
+    var expanded by remember { mutableStateOf(false) }
 
     DisposableEffect(key1 = activity) {
         val listener = Consumer<Intent> { intent ->
@@ -250,33 +253,34 @@ internal fun EditPageScreen(
             }
         }
 
-        AnimatedVisibility(
+        ExpandableFloatingActionButton(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(paddingValues),
-            visible = isAtTop,
-            enter = fadeIn(),
-            exit = fadeOut(),
-        ) {
-            ActionButtons(
-                onAdd = {
-                    currentPageItems = currentPageItems.toMutableList().apply {
-                        add(PageItem(id = maxOf { it.id } + 1, gridItems = emptyList()))
-                    }
-                },
-                onCancel = {
-                    onUpdateScreen(Screen.Pager)
-                },
-                onSave = {
-                    onSaveEditPage(
-                        selectedId,
-                        currentPageItems,
-                        pageItemsToDelete,
-                        editPageData.associate,
-                    )
-                },
-            )
-        }
+                .align(Alignment.BottomEnd)
+                .padding(
+                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                    bottom = paddingValues.calculateBottomPadding(),
+                ),
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+            onAdd = {
+                currentPageItems = currentPageItems.toMutableList().apply {
+                    add(PageItem(id = maxOf { it.id } + 1, gridItems = emptyList()))
+                }
+            },
+            onSave = {
+                onSaveEditPage(
+                    selectedId,
+                    currentPageItems,
+                    pageItemsToDelete,
+                    editPageData.associate,
+                )
+
+                expanded = false
+            },
+            onCancel = {
+                onUpdateScreen(Screen.Pager)
+            },
+        )
     }
 }
 
@@ -321,41 +325,67 @@ private fun PageButtons(
 }
 
 @Composable
-private fun ActionButtons(
+private fun ExpandableFloatingActionButton(
     modifier: Modifier = Modifier,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
     onAdd: () -> Unit,
-    onCancel: () -> Unit,
     onSave: () -> Unit,
+    onCancel: () -> Unit,
 ) {
-    Surface(
-        modifier = modifier.padding(10.dp),
-        shape = RoundedCornerShape(30.dp),
-        tonalElevation = 10.dp,
-    ) {
-        Row(
-            modifier = Modifier.padding(5.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+    Column(modifier = modifier.padding(15.dp)) {
+        AnimatedVisibility(
+            visible = expanded,
+            enter = fadeIn() + slideInHorizontally { it },
+            exit = fadeOut() + slideOutHorizontally { it },
         ) {
-            IconButton(onClick = onCancel) {
-                Icon(
-                    imageVector = EblanLauncherIcons.Close,
-                    contentDescription = null,
-                )
-            }
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                ElevatedButton(onClick = onAdd) {
+                    Text(
+                        text = "Add",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
 
-            IconButton(onClick = onSave) {
-                Icon(
-                    imageVector = EblanLauncherIcons.Save,
-                    contentDescription = null,
-                )
-            }
+                ElevatedButton(
+                    onClick = onSave,
+                ) {
+                    Text(
+                        text = "Save",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
 
-            IconButton(onClick = onAdd) {
-                Icon(
-                    imageVector = EblanLauncherIcons.Add,
-                    contentDescription = null,
-                )
+                ElevatedButton(
+                    onClick = onCancel,
+                ) {
+                    Text(
+                        text = "Cancel",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
             }
+        }
+
+        Spacer(modifier = Modifier.height(15.dp))
+
+        FloatingActionButton(
+            modifier = Modifier.align(Alignment.End),
+            onClick = {
+                onExpandedChange(!expanded)
+            },
+        ) {
+            Icon(
+                imageVector = if (expanded) {
+                    EblanLauncherIcons.Close
+                } else {
+                    EblanLauncherIcons.Add
+                },
+                contentDescription = null,
+            )
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
@@ -62,7 +62,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
@@ -98,6 +98,8 @@ internal fun EditPageScreen(
     requireNotNull(editPageData)
 
     val density = LocalDensity.current
+
+    val layoutDirection = LocalLayoutDirection.current
 
     val topPadding = with(density) {
         paddingValues.calculateTopPadding().roundToPx()
@@ -257,7 +259,7 @@ internal fun EditPageScreen(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(
-                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                    end = paddingValues.calculateEndPadding(layoutDirection),
                     bottom = paddingValues.calculateBottomPadding(),
                 ),
             expanded = expanded,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -127,7 +126,7 @@ internal fun SharedTransitionScope.FolderScreen(
     val androidLauncherAppsWrapper = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -55,9 +55,9 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.eblan.launcher.domain.model.GridItem
@@ -122,10 +122,12 @@ internal fun SharedTransitionScope.FolderScreen(
 
     val context = LocalContext.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val androidLauncherAppsWrapper = LocalLauncherApps.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -18,8 +18,6 @@
 package com.eblan.launcher.feature.home.screen.pager
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -63,11 +61,11 @@ internal fun handleAnimateScrollToPage(
     if (gridItemSource == null || !isDragging) return
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
+        paddingValues.calculateRightPadding(layoutDirection).roundToPx()
     }
 
     val horizontalPadding = leftPadding + rightPadding
@@ -210,11 +208,11 @@ internal suspend fun handleDragGridItem(
     delay(100L)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
+        paddingValues.calculateRightPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -614,11 +612,11 @@ internal suspend fun handleConflictingGridItem(
     }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
+        paddingValues.calculateRightPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -55,6 +55,7 @@ internal fun handleAnimateScrollToPage(
     isDragging: Boolean,
     paddingValues: PaddingValues,
     screenWidth: Int,
+    layoutDirection: LayoutDirection,
     onUpdateDockPageDirection: (PageDirection?) -> Unit,
     onUpdateFolderPageDirection: (PageDirection?) -> Unit,
     onUpdateGridPageDirection: (PageDirection?) -> Unit,
@@ -62,11 +63,11 @@ internal fun handleAnimateScrollToPage(
     if (gridItemSource == null || !isDragging) return
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
     }
 
     val horizontalPadding = leftPadding + rightPadding
@@ -168,6 +169,7 @@ internal suspend fun handleDragGridItem(
     screenHeight: Int,
     screenWidth: Int,
     moveGridItemResult: MoveGridItemResult?,
+    layoutDirection: LayoutDirection,
     onMoveFolderGridItem: (
         conflictingGridItem: GridItem,
         movingFolderGridItem: GridItem,
@@ -208,11 +210,11 @@ internal suspend fun handleDragGridItem(
     delay(100L)
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -563,6 +565,7 @@ internal suspend fun handleConflictingGridItem(
     screenHeight: Int,
     screenWidth: Int,
     lockMovement: Boolean,
+    layoutDirection: LayoutDirection,
     onShowFolderWhenDragging: (
         conflictingGridItem: GridItem,
         movingGridItem: GridItem,
@@ -611,11 +614,11 @@ internal suspend fun handleConflictingGridItem(
     }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
@@ -98,7 +98,7 @@ internal fun GridItemPopup(
     val layoutDirection = LocalLayoutDirection.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -215,7 +215,7 @@ internal fun FolderGridItemPopup(
     val layoutDirection = LocalLayoutDirection.current
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
@@ -40,9 +40,9 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.EblanAppWidgetProviderInfo
@@ -95,8 +95,10 @@ internal fun GridItemPopup(
 
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -210,8 +212,10 @@ internal fun FolderGridItemPopup(
 
     val density = LocalDensity.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -62,8 +62,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
 import com.eblan.launcher.domain.model.AppDrawerSettings
@@ -215,6 +215,8 @@ internal fun PagerScreen(
 ) {
     val context = LocalContext.current
 
+    val layoutDirection = LocalLayoutDirection.current
+
     val androidLauncherAppsWrapper = LocalLauncherApps.current
 
     val androidWallpaperManagerWrapper = LocalWallpaperManager.current
@@ -254,11 +256,11 @@ internal fun PagerScreen(
     }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(LayoutDirection.Ltr).roundToPx()
+        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {
@@ -449,6 +451,7 @@ internal fun PagerScreen(
             gridItemSource = gridItemSource,
             isVisibleOverlay = isVisibleOverlay,
             moveGridItemResult = moveGridItemResult,
+            layoutDirection = layoutDirection,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onMoveGridItem = onMoveGridItem,
         )
@@ -507,6 +510,7 @@ internal fun PagerScreen(
             moveGridItemResult = moveGridItemResult,
             paddingValues = paddingValues,
             isVisibleOverlay = isVisibleOverlay,
+            layoutDirection = layoutDirection,
             onShowFolderWhenDragging = onShowFolderWhenDragging,
         )
     }
@@ -517,6 +521,7 @@ internal fun PagerScreen(
             folderGridItem = folderGridItem,
             paddingValues = paddingValues,
             gridItemSource = gridItemSource,
+            layoutDirection = layoutDirection,
         )
     }
 
@@ -688,8 +693,8 @@ internal fun PagerScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(
-                            start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                            end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                            start = paddingValues.calculateStartPadding(layoutDirection),
+                            end = paddingValues.calculateEndPadding(layoutDirection),
                         ),
                     columns = homeSettings.columns,
                     gridItems = gridItemsByPage[page],
@@ -808,8 +813,8 @@ internal fun PagerScreen(
                     .fillMaxWidth()
                     .height(dockHeight)
                     .padding(
-                        start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                        end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                        start = paddingValues.calculateStartPadding(layoutDirection),
+                        end = paddingValues.calculateEndPadding(layoutDirection),
                     ),
                 userScrollEnabled = !isVisibleOverlay,
             ) { index ->

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -256,11 +256,11 @@ internal fun PagerScreen(
     }
 
     val leftPadding = with(density) {
-        paddingValues.calculateStartPadding(layoutDirection).roundToPx()
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
 
     val rightPadding = with(density) {
-        paddingValues.calculateEndPadding(layoutDirection).roundToPx()
+        paddingValues.calculateRightPadding(layoutDirection).roundToPx()
     }
 
     val topPadding = with(density) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import com.eblan.launcher.domain.common.IconKeyGenerator
@@ -381,6 +382,7 @@ internal class PagerScreenState(
         gridItemSource: GridItemSource?,
         isVisibleOverlay: Boolean,
         moveGridItemResult: MoveGridItemResult?,
+        layoutDirection: LayoutDirection,
         onMoveFolderGridItem: (
             conflictingGridItem: GridItem,
             movingFolderGridItem: GridItem,
@@ -428,6 +430,7 @@ internal class PagerScreenState(
             screenHeight = screenHeight,
             screenWidth = screenWidth,
             moveGridItemResult = moveGridItemResult,
+            layoutDirection = layoutDirection,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onMoveGridItem = onMoveGridItem,
             onUpdateAssociate = { newAssociate ->
@@ -510,6 +513,7 @@ internal class PagerScreenState(
         moveGridItemResult: MoveGridItemResult?,
         paddingValues: PaddingValues,
         isVisibleOverlay: Boolean,
+        layoutDirection: LayoutDirection,
         onShowFolderWhenDragging: (
             conflictingGridItem: GridItem,
             movingGridItem: GridItem,
@@ -530,6 +534,7 @@ internal class PagerScreenState(
             screenHeight = screenHeight,
             screenWidth = screenWidth,
             lockMovement = experimentalSettings.lockMovement,
+            layoutDirection = layoutDirection,
             onShowFolderWhenDragging = onShowFolderWhenDragging,
             onUpdateFolderPopupBounds = { intOffset, intSize ->
                 lastFolderPopupX = intOffset.x
@@ -553,6 +558,7 @@ internal class PagerScreenState(
         folderGridItem: GridItem?,
         paddingValues: PaddingValues,
         gridItemSource: GridItemSource?,
+        layoutDirection: LayoutDirection,
     ) {
         handleAnimateScrollToPage(
             associate = associate,
@@ -565,6 +571,7 @@ internal class PagerScreenState(
             isDragging = isDragging,
             paddingValues = paddingValues,
             screenWidth = screenWidth,
+            layoutDirection = layoutDirection,
             onUpdateDockPageDirection = { pageDirection ->
                 dockPageDirection = pageDirection
             },

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -78,11 +78,11 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import coil3.compose.AsyncImage
@@ -202,6 +202,8 @@ private fun Success(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+
     val horizontalPagerState = rememberPagerState(
         pageCount = {
             eblanShortcutConfigs.keys.size
@@ -241,8 +243,8 @@ private fun Success(
             .fillMaxSize()
             .padding(
                 top = paddingValues.calculateTopPadding(),
-                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                start = paddingValues.calculateStartPadding(layoutDirection),
+                end = paddingValues.calculateEndPadding(layoutDirection),
             ),
     ) {
         SearchBar(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -243,7 +242,7 @@ private fun Success(
             .fillMaxSize()
             .padding(
                 top = paddingValues.calculateTopPadding(),
-                start = paddingValues.calculateStartPadding(layoutDirection),
+                start = paddingValues.calculateLeftPadding(layoutDirection),
                 end = paddingValues.calculateEndPadding(layoutDirection),
             ),
     ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -73,11 +73,11 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import coil3.compose.AsyncImage
@@ -199,6 +199,8 @@ private fun Success(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+
     val scope = rememberCoroutineScope()
 
     val lazyListState = rememberLazyListState()
@@ -266,8 +268,8 @@ private fun Success(
             .fillMaxSize()
             .padding(
                 top = paddingValues.calculateTopPadding(),
-                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                start = paddingValues.calculateStartPadding(layoutDirection),
+                end = paddingValues.calculateEndPadding(layoutDirection),
             ),
     ) {
         SearchBar(


### PR DESCRIPTION
Closes #764

- Replaced the horizontal `ActionButtons` surface with a new `ExpandableFloatingActionButton` positioned at the bottom-end of the screen.
- Removed scroll-dependent visibility logic (`isAtTop`), making page actions accessible regardless of the current scroll position in the list.
- Implemented a vertical expansion menu containing `ElevatedButton` components for "Add", "Save", and "Cancel" actions.
- Added slide and fade animations for the expansion transitions.
- Updated the `onSave` callback to automatically collapse the FAB menu upon execution.
- Improved layout handling by explicitly calculating end and bottom padding for the FAB container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned editing screen with an expandable FAB exposing Add/Save/Cancel actions and animated transitions; FAB toggles Add/Close icons.
* **Improvements**
  * Layout-direction aware padding and positioning across screens, popups, pagers and drag/drop interactions (better RTL/LTR support).
* **Bug Fixes**
  * Removed scroll-position–triggered action row for a more consistent editing UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->