### PR TITLE
Simplified Gradle toolchain configuration and updated native library packaging rules

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -55,6 +55,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     resources {
                         excludes += "/META-INF/{AL2.0,LGPL2.1}"
                     }
+
+                    jniLibs.keepDebugSymbols.add("**/*.so")
                 }
             }
 

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -9,5 +9,4 @@ toolchainUrl.UNIX.AARCH64=https\://api.foojay.io/disco/v3.0/ids/536afcd1dff54025
 toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/67a0fee3c4236b6397dcbe8575ca2011/redirect
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/23adb857f3cb3cbe28750bc7faa7abc0/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/ac151d55def6b6a9a159dc4cb4642851/redirect
-toolchainVendor=JETBRAINS
 toolchainVersion=21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,10 +13,6 @@ pluginManagement {
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Fixes #780 

- Removed the `foojay-resolver-convention` plugin from `settings.gradle.kts` and the `toolchainVendor` property from `gradle-daemon-jvm.properties`.
- Updated `AndroidApplicationConventionPlugin` to preserve debug symbols for JNI libraries by adding `**/*.so` to the `keepDebugSymbols` packaging configuration.
- Added a standard XML declaration header to `.idea/misc.xml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to retain debug symbols for native libraries.
  * Refined Gradle daemon JVM properties and plugin settings.
  * Updated IDE configuration formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JackEblan/YagniLauncher/pull/782)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->