### PR TITLE
Implemented configuration for folder cell dimensions in home settings

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/home/home_settings.proto
+++ b/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/home/home_settings.proto
@@ -21,8 +21,8 @@ message HomeSettingsProto {
   bool dockInfiniteScroll = 15;
   int32 dockInitialPage = 16;
   bool addNewAppsToHomeScreen = 17;
-  int32 minCellWidth = 18;
-  int32 minCellHeight = 19;
-  int32 maxCellWidth = 20;
-  int32 maxCellHeight = 21;
+  int32 minFolderCellWidth = 18;
+  int32 minFolderCellHeight = 19;
+  int32 maxFolderCellWidth = 20;
+  int32 maxFolderCellHeight = 21;
 }

--- a/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/home/home_settings.proto
+++ b/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/home/home_settings.proto
@@ -21,4 +21,8 @@ message HomeSettingsProto {
   bool dockInfiniteScroll = 15;
   int32 dockInitialPage = 16;
   bool addNewAppsToHomeScreen = 17;
+  int32 minCellWidth = 18;
+  int32 minCellHeight = 19;
+  int32 maxCellWidth = 20;
+  int32 maxCellHeight = 21;
 }

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -62,6 +62,10 @@ internal fun HomeSettingsProto.toHomeSettings(): HomeSettings = HomeSettings(
     dockInfiniteScroll = dockInfiniteScroll,
     dockInitialPage = dockInitialPage,
     addNewAppsToHomeScreen = addNewAppsToHomeScreen,
+    minCellWidth = minCellWidth,
+    minCellHeight = minCellHeight,
+    maxCellWidth = maxCellWidth,
+    maxCellHeight = maxCellHeight,
 )
 
 internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = AppDrawerSettings(
@@ -111,7 +115,12 @@ internal fun HomeSettings.toHomeSettingsProto(): HomeSettingsProto = HomeSetting
     .setGridItemSettingsProto(gridItemSettings.toGridItemSettingsProto())
     .setLockScreenOrientation(lockScreenOrientation).setDockPageCount(dockPageCount)
     .setDockInfiniteScroll(dockInfiniteScroll).setDockInitialPage(dockInitialPage)
-    .setAddNewAppsToHomeScreen(addNewAppsToHomeScreen).build()
+    .setAddNewAppsToHomeScreen(addNewAppsToHomeScreen)
+    .setMinCellWidth(minCellWidth)
+    .setMinCellHeight(minCellHeight)
+    .setMaxCellWidth(maxCellWidth)
+    .setMaxCellHeight(maxCellHeight)
+    .build()
 
 internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProto = AppDrawerSettingsProto.newBuilder().setAppDrawerColumns(appDrawerColumns)
     .setAppDrawerRowsHeight(appDrawerRowsHeight)

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -62,10 +62,10 @@ internal fun HomeSettingsProto.toHomeSettings(): HomeSettings = HomeSettings(
     dockInfiniteScroll = dockInfiniteScroll,
     dockInitialPage = dockInitialPage,
     addNewAppsToHomeScreen = addNewAppsToHomeScreen,
-    minCellWidth = minCellWidth,
-    minCellHeight = minCellHeight,
-    maxCellWidth = maxCellWidth,
-    maxCellHeight = maxCellHeight,
+    minFolderCellWidth = minFolderCellWidth,
+    minFolderCellHeight = minFolderCellHeight,
+    maxFolderCellWidth = maxFolderCellWidth,
+    maxFolderCellHeight = maxFolderCellHeight,
 )
 
 internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = AppDrawerSettings(
@@ -116,10 +116,10 @@ internal fun HomeSettings.toHomeSettingsProto(): HomeSettingsProto = HomeSetting
     .setLockScreenOrientation(lockScreenOrientation).setDockPageCount(dockPageCount)
     .setDockInfiniteScroll(dockInfiniteScroll).setDockInitialPage(dockInitialPage)
     .setAddNewAppsToHomeScreen(addNewAppsToHomeScreen)
-    .setMinCellWidth(minCellWidth)
-    .setMinCellHeight(minCellHeight)
-    .setMaxCellWidth(maxCellWidth)
-    .setMaxCellHeight(maxCellHeight)
+    .setMinFolderCellWidth(minFolderCellWidth)
+    .setMinFolderCellHeight(minFolderCellHeight)
+    .setMaxFolderCellWidth(maxFolderCellWidth)
+    .setMaxFolderCellHeight(maxFolderCellHeight)
     .build()
 
 internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProto = AppDrawerSettingsProto.newBuilder().setAppDrawerColumns(appDrawerColumns)

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/migration/DataStoreMigration.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/migration/DataStoreMigration.kt
@@ -24,11 +24,19 @@ import com.eblan.launcher.data.datastore.proto.copy
 internal class DataStoreMigration : DataMigration<UserDataProto> {
     override suspend fun shouldMigrate(currentData: UserDataProto): Boolean = currentData.homeSettingsProto.dockPageCount == 0 ||
         currentData.appDrawerSettingsProto.horizontalAppDrawerColumns == 0 ||
-        currentData.appDrawerSettingsProto.horizontalAppDrawerRows == 0
+        currentData.appDrawerSettingsProto.horizontalAppDrawerRows == 0 ||
+        currentData.homeSettingsProto.minFolderCellWidth == 0 ||
+        currentData.homeSettingsProto.minFolderCellHeight == 0 ||
+        currentData.homeSettingsProto.maxFolderCellWidth == 0 ||
+        currentData.homeSettingsProto.maxFolderCellHeight == 0
 
     override suspend fun migrate(currentData: UserDataProto): UserDataProto = currentData.copy {
         homeSettingsProto = homeSettingsProto.toBuilder()
             .setDockPageCount(1)
+            .setMinFolderCellWidth(64)
+            .setMinFolderCellHeight(96)
+            .setMaxFolderCellWidth(80)
+            .setMaxFolderCellHeight(120)
             .build()
 
         appDrawerSettingsProto = appDrawerSettingsProto.toBuilder()

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/HomeSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/HomeSettings.kt
@@ -33,8 +33,8 @@ data class HomeSettings(
     val dockInfiniteScroll: Boolean,
     val dockInitialPage: Int,
     val addNewAppsToHomeScreen: Boolean,
-    val minCellWidth: Int,
-    val minCellHeight: Int,
-    val maxCellWidth: Int,
-    val maxCellHeight: Int,
+    val minFolderCellWidth: Int,
+    val minFolderCellHeight: Int,
+    val maxFolderCellWidth: Int,
+    val maxFolderCellHeight: Int,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/HomeSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/HomeSettings.kt
@@ -33,4 +33,8 @@ data class HomeSettings(
     val dockInfiniteScroll: Boolean,
     val dockInitialPage: Int,
     val addNewAppsToHomeScreen: Boolean,
+    val minCellWidth: Int,
+    val minCellHeight: Int,
+    val maxCellWidth: Int,
+    val maxCellHeight: Int,
 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.GridItemSettings
+import com.eblan.launcher.domain.model.HomeSettings
 import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.feature.home.component.FolderGridLayout
 import com.eblan.launcher.feature.home.component.PageIndicator
@@ -90,6 +91,7 @@ internal fun SharedTransitionScope.FolderScreen(
     isMoveFolderGridItemOutsideFolder: Boolean,
     hasShortcutHostPermission: Boolean,
     moveGridItemResult: MoveGridItemResult?,
+    homeSettings: HomeSettings,
     onDismissRequest: () -> Unit,
     onMoveFolderGridItemOutsideFolder: () -> Unit,
     onOpenAppDrawer: () -> Unit,
@@ -132,16 +134,16 @@ internal fun SharedTransitionScope.FolderScreen(
         paddingValues.calculateTopPadding().roundToPx()
     }
 
-    val minCellWidthDp = 80.dp
-    val maxCellWidthDp = 100.dp
+    val minCellWidthDp = homeSettings.minFolderCellWidth.dp
+    val minCellHeightDp = homeSettings.minFolderCellHeight.dp
 
-    val minCellHeightDp = 100.dp
-    val maxCellHeightDp = 150.dp
+    val maxCellWidthDp = homeSettings.maxFolderCellWidth.dp
+    val maxCellHeightDp = homeSettings.maxFolderCellHeight.dp
 
     val minCellWidthPx = with(density) { minCellWidthDp.roundToPx() }
-    val maxCellWidthPx = with(density) { maxCellWidthDp.roundToPx() }
-
     val minCellHeightPx = with(density) { minCellHeightDp.roundToPx() }
+
+    val maxCellWidthPx = with(density) { maxCellWidthDp.roundToPx() }
     val maxCellHeightPx = with(density) { maxCellHeightDp.roundToPx() }
 
     val availableWidth = (safeDrawingWidth - leftPadding * 2).coerceAtLeast(0)
@@ -167,8 +169,6 @@ internal fun SharedTransitionScope.FolderScreen(
         y = y.coerceIn(0, maximumY) + topPadding,
     )
 
-    val progress = remember { Animatable(0f) }
-
     val startWidth = folderPopupIntSize.width.toFloat()
     val startHeight = folderPopupIntSize.height.toFloat()
 
@@ -180,6 +180,8 @@ internal fun SharedTransitionScope.FolderScreen(
 
     val endCenterX = intOffset.x + endWidth / 2f
     val endCenterY = intOffset.y + endHeight / 2f
+
+    val progress = remember { Animatable(0f) }
 
     val animatedRect by remember(
         startWidth,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -70,6 +70,8 @@ import com.eblan.launcher.feature.home.component.swipeGestures
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
+import com.eblan.launcher.feature.home.util.getHorizontalAlignment
+import com.eblan.launcher.feature.home.util.getVerticalArrangement
 import com.eblan.launcher.feature.home.util.handleDrag
 import com.eblan.launcher.feature.home.util.onDoubleTap
 import com.eblan.launcher.feature.home.util.onLongPress
@@ -273,6 +275,12 @@ private fun SharedTransitionScope.InteractiveFolderApplicationInfoGridItem(
 
     val scope = rememberCoroutineScope()
 
+    val horizontalAlignment =
+        getHorizontalAlignment(horizontalAlignment = gridItemSettings.horizontalAlignment)
+
+    val verticalArrangement =
+        getVerticalArrangement(verticalArrangement = gridItemSettings.verticalArrangement)
+
     val maxLines = if (gridItemSettings.singleLineLabel) 1 else Int.MAX_VALUE
 
     val icon = iconPackFilePaths[data.componentName] ?: data.icon
@@ -361,7 +369,8 @@ private fun SharedTransitionScope.InteractiveFolderApplicationInfoGridItem(
                 color = Color(gridItemSettings.customBackgroundColor),
                 shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = horizontalAlignment,
+        verticalArrangement = verticalArrangement,
     ) {
         Box(
             modifier = Modifier
@@ -477,6 +486,12 @@ private fun SharedTransitionScope.InteractiveFolderShortcutInfoGridItem(
 
     val scope = rememberCoroutineScope()
 
+    val horizontalAlignment =
+        getHorizontalAlignment(horizontalAlignment = gridItemSettings.horizontalAlignment)
+
+    val verticalArrangement =
+        getVerticalArrangement(verticalArrangement = gridItemSettings.verticalArrangement)
+
     val maxLines = if (gridItemSettings.singleLineLabel) 1 else Int.MAX_VALUE
 
     val customIcon = data.customIcon ?: data.icon
@@ -564,7 +579,8 @@ private fun SharedTransitionScope.InteractiveFolderShortcutInfoGridItem(
                 color = Color(gridItemSettings.customBackgroundColor),
                 shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = horizontalAlignment,
+        verticalArrangement = verticalArrangement,
     ) {
         Box(
             modifier = Modifier
@@ -672,6 +688,12 @@ private fun SharedTransitionScope.InteractiveFolderShortcutConfigGridItem(
     val graphicsLayer = rememberGraphicsLayer()
 
     val scope = rememberCoroutineScope()
+
+    val horizontalAlignment =
+        getHorizontalAlignment(horizontalAlignment = gridItemSettings.horizontalAlignment)
+
+    val verticalArrangement =
+        getVerticalArrangement(verticalArrangement = gridItemSettings.verticalArrangement)
 
     val maxLines = if (gridItemSettings.singleLineLabel) 1 else Int.MAX_VALUE
 
@@ -784,7 +806,8 @@ private fun SharedTransitionScope.InteractiveFolderShortcutConfigGridItem(
                 color = Color(gridItemSettings.customBackgroundColor),
                 shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = horizontalAlignment,
+        verticalArrangement = verticalArrangement,
     ) {
         AsyncImage(
             model = Builder(LocalContext.current).data(icon)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -1003,6 +1003,7 @@ internal fun PagerScreen(
                 isMoveFolderGridItemOutsideFolder = pagerScreenState.isMoveFolderGridItemOutsideFolder,
                 hasShortcutHostPermission = hasShortcutHostPermission,
                 moveGridItemResult = moveGridItemResult,
+                homeSettings = homeSettings,
                 onDismissRequest = {
                     pagerScreenState.dismissFolder(onUpdateFolderGridItemId = onUpdateFolderGridItemId)
                 },

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/HomeSettingsScreen.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/HomeSettingsScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.feature.settings.home.dialog.FolderCellDimensionDialog
 import com.eblan.launcher.feature.settings.home.model.HomeSettingsUiState
 import com.eblan.launcher.ui.dialog.SingleTextFieldDialog
 import com.eblan.launcher.ui.dialog.TwoTextFieldsDialog
@@ -124,6 +125,8 @@ private fun Success(
     var showDockGridDialog by remember { mutableStateOf(false) }
 
     var showDockHeightDialog by remember { mutableStateOf(false) }
+
+    var showFolderCellDimensionDialog by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -225,6 +228,26 @@ private fun Success(
                 subtitle = "Seamless loop page scroll",
                 onCheckedChange = { dockInfiniteScroll ->
                     onUpdateHomeSettings(homeSettings.copy(dockInfiniteScroll = dockInfiniteScroll))
+                },
+            )
+        }
+
+        Text(
+            modifier = Modifier.padding(15.dp),
+            text = "Folder",
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        ElevatedCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 15.dp),
+        ) {
+            SettingsColumn(
+                title = "Folder Cell Dimension",
+                subtitle = "Folder cell dimension",
+                onClick = {
+                    showFolderCellDimensionDialog = true
                 },
             )
         }
@@ -382,6 +405,16 @@ private fun Success(
                     showDockHeightDialog = false
                 }
             },
+        )
+    }
+
+    if (showFolderCellDimensionDialog) {
+        FolderCellDimensionDialog(
+            homeSettings = homeSettings,
+            onDismissRequest = {
+                showFolderCellDimensionDialog = false
+            },
+            onUpdateHomeSettings = onUpdateHomeSettings,
         )
     }
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/FolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/FolderCellDimensionDialog.kt
@@ -1,0 +1,234 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.eblan.launcher.designsystem.component.EblanDialogContainer
+import com.eblan.launcher.domain.model.HomeSettings
+
+@Composable
+internal fun FolderCellDimensionDialog(
+    modifier: Modifier = Modifier,
+    homeSettings: HomeSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateHomeSettings: (HomeSettings) -> Unit,
+) {
+    var minCellWidth by remember { mutableStateOf("${homeSettings.minCellWidth}") }
+    var minCellHeight by remember { mutableStateOf("${homeSettings.minCellHeight}") }
+    var maxCellWidth by remember { mutableStateOf("${homeSettings.maxCellWidth}") }
+    var maxCellHeight by remember { mutableStateOf("${homeSettings.maxCellHeight}") }
+
+    var minCellWidthIsError by remember { mutableStateOf(false) }
+    var minCellHeightIsError by remember { mutableStateOf(false) }
+    var maxCellWidthIsError by remember { mutableStateOf(false) }
+    var maxCellHeightIsError by remember { mutableStateOf(false) }
+
+    EblanDialogContainer(
+        content = {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(10.dp),
+            ) {
+                Text(text = "Folder Cell Dimension", style = MaterialTheme.typography.titleLarge)
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        modifier = Modifier.padding(15.dp),
+                        text = "Min",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        TextField(
+                            value = minCellWidth,
+                            onValueChange = {
+                                minCellWidth = it
+                            },
+                            modifier = Modifier.weight(1f),
+                            label = {
+                                Text(text = "Min Cell Width")
+                            },
+                            supportingText = {
+                                if (minCellWidthIsError) {
+                                    Text(text = "Min Cell Width is not valid")
+                                }
+                            },
+                            isError = minCellWidthIsError,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                        )
+
+                        Spacer(modifier = Modifier.width(5.dp))
+
+                        TextField(
+                            value = minCellHeight,
+                            onValueChange = {
+                                minCellHeight = it
+                            },
+                            modifier = Modifier.weight(1f),
+                            label = {
+                                Text(text = "Min Cell Height")
+                            },
+                            supportingText = {
+                                if (minCellHeightIsError) {
+                                    Text(text = "Min Cell Height is not valid")
+                                }
+                            },
+                            isError = minCellHeightIsError,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                        )
+                    }
+
+                    Text(
+                        modifier = Modifier.padding(15.dp),
+                        text = "Max",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        TextField(
+                            value = maxCellWidth,
+                            onValueChange = {
+                                maxCellWidth = it
+                            },
+                            modifier = Modifier.weight(1f),
+                            label = {
+                                Text(text = "Max Cell Width")
+                            },
+                            supportingText = {
+                                if (maxCellWidthIsError) {
+                                    Text(text = "Max Cell Width is not valid")
+                                }
+                            },
+                            isError = maxCellWidthIsError,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                        )
+
+                        Spacer(modifier = Modifier.width(5.dp))
+
+                        TextField(
+                            value = maxCellHeight,
+                            onValueChange = {
+                                maxCellHeight = it
+                            },
+                            modifier = Modifier.weight(1f),
+                            label = {
+                                Text(text = "Max Cell Height")
+                            },
+                            supportingText = {
+                                if (maxCellHeightIsError) {
+                                    Text(text = "Max Cell Height is not valid")
+                                }
+                            },
+                            isError = maxCellHeightIsError,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(
+                            onClick = onDismissRequest,
+                        ) {
+                            Text(text = "Cancel")
+                        }
+                        TextButton(
+                            onClick = {
+                                val minCellWidth = try {
+                                    minCellWidth.toInt()
+                                } catch (_: NumberFormatException) {
+                                    minCellWidthIsError = true
+                                    0
+                                }
+
+                                val minCellHeight = try {
+                                    minCellHeight.toInt()
+                                } catch (_: NumberFormatException) {
+                                    minCellHeightIsError = true
+                                    0
+                                }
+
+                                val maxCellWidth = try {
+                                    maxCellWidth.toInt()
+                                } catch (_: NumberFormatException) {
+                                    maxCellWidthIsError = true
+                                    0
+                                }
+
+                                val maxCellHeight = try {
+                                    maxCellHeight.toInt()
+                                } catch (_: NumberFormatException) {
+                                    maxCellHeightIsError = true
+                                    0
+                                }
+
+                                if (minCellWidth > 0 && minCellHeight > 0 &&
+                                    maxCellWidth > 0 && maxCellHeight > 0
+                                ) {
+                                    onUpdateHomeSettings(
+                                        homeSettings.copy(
+                                            minCellWidth = minCellWidth,
+                                            minCellHeight = minCellHeight,
+                                            maxCellWidth = maxCellWidth,
+                                            maxCellHeight = maxCellHeight,
+                                        ),
+                                    )
+
+                                    onDismissRequest()
+                                }
+                            },
+                        ) {
+                            Text(text = "Update")
+                        }
+                    }
+                }
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/FolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/FolderCellDimensionDialog.kt
@@ -48,15 +48,15 @@ internal fun FolderCellDimensionDialog(
     onDismissRequest: () -> Unit,
     onUpdateHomeSettings: (HomeSettings) -> Unit,
 ) {
-    var minCellWidth by remember { mutableStateOf("${homeSettings.minCellWidth}") }
-    var minCellHeight by remember { mutableStateOf("${homeSettings.minCellHeight}") }
-    var maxCellWidth by remember { mutableStateOf("${homeSettings.maxCellWidth}") }
-    var maxCellHeight by remember { mutableStateOf("${homeSettings.maxCellHeight}") }
+    var minFolderCellWidth by remember { mutableStateOf("${homeSettings.minFolderCellWidth}") }
+    var minFolderCellHeight by remember { mutableStateOf("${homeSettings.minFolderCellHeight}") }
+    var maxFolderCellWidth by remember { mutableStateOf("${homeSettings.maxFolderCellWidth}") }
+    var maxFolderCellHeight by remember { mutableStateOf("${homeSettings.maxFolderCellHeight}") }
 
-    var minCellWidthIsError by remember { mutableStateOf(false) }
-    var minCellHeightIsError by remember { mutableStateOf(false) }
-    var maxCellWidthIsError by remember { mutableStateOf(false) }
-    var maxCellHeightIsError by remember { mutableStateOf(false) }
+    var minFolderCellWidthIsError by remember { mutableStateOf(false) }
+    var minFolderCellHeightIsError by remember { mutableStateOf(false) }
+    var maxFolderCellWidthIsError by remember { mutableStateOf(false) }
+    var maxFolderCellHeightIsError by remember { mutableStateOf(false) }
 
     EblanDialogContainer(
         content = {
@@ -78,20 +78,20 @@ internal fun FolderCellDimensionDialog(
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                         TextField(
-                            value = minCellWidth,
+                            value = minFolderCellWidth,
                             onValueChange = {
-                                minCellWidth = it
+                                minFolderCellWidth = it
                             },
                             modifier = Modifier.weight(1f),
                             label = {
                                 Text(text = "Min Cell Width")
                             },
                             supportingText = {
-                                if (minCellWidthIsError) {
+                                if (minFolderCellWidthIsError) {
                                     Text(text = "Min Cell Width is not valid")
                                 }
                             },
-                            isError = minCellWidthIsError,
+                            isError = minFolderCellWidthIsError,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             singleLine = true,
                         )
@@ -99,20 +99,20 @@ internal fun FolderCellDimensionDialog(
                         Spacer(modifier = Modifier.width(5.dp))
 
                         TextField(
-                            value = minCellHeight,
+                            value = minFolderCellHeight,
                             onValueChange = {
-                                minCellHeight = it
+                                minFolderCellHeight = it
                             },
                             modifier = Modifier.weight(1f),
                             label = {
                                 Text(text = "Min Cell Height")
                             },
                             supportingText = {
-                                if (minCellHeightIsError) {
+                                if (minFolderCellHeightIsError) {
                                     Text(text = "Min Cell Height is not valid")
                                 }
                             },
-                            isError = minCellHeightIsError,
+                            isError = minFolderCellHeightIsError,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             singleLine = true,
                         )
@@ -126,20 +126,20 @@ internal fun FolderCellDimensionDialog(
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                         TextField(
-                            value = maxCellWidth,
+                            value = maxFolderCellWidth,
                             onValueChange = {
-                                maxCellWidth = it
+                                maxFolderCellWidth = it
                             },
                             modifier = Modifier.weight(1f),
                             label = {
                                 Text(text = "Max Cell Width")
                             },
                             supportingText = {
-                                if (maxCellWidthIsError) {
+                                if (maxFolderCellWidthIsError) {
                                     Text(text = "Max Cell Width is not valid")
                                 }
                             },
-                            isError = maxCellWidthIsError,
+                            isError = maxFolderCellWidthIsError,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             singleLine = true,
                         )
@@ -147,20 +147,20 @@ internal fun FolderCellDimensionDialog(
                         Spacer(modifier = Modifier.width(5.dp))
 
                         TextField(
-                            value = maxCellHeight,
+                            value = maxFolderCellHeight,
                             onValueChange = {
-                                maxCellHeight = it
+                                maxFolderCellHeight = it
                             },
                             modifier = Modifier.weight(1f),
                             label = {
                                 Text(text = "Max Cell Height")
                             },
                             supportingText = {
-                                if (maxCellHeightIsError) {
+                                if (maxFolderCellHeightIsError) {
                                     Text(text = "Max Cell Height is not valid")
                                 }
                             },
-                            isError = maxCellHeightIsError,
+                            isError = maxFolderCellHeightIsError,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             singleLine = true,
                         )
@@ -180,30 +180,30 @@ internal fun FolderCellDimensionDialog(
                         TextButton(
                             onClick = {
                                 val minCellWidth = try {
-                                    minCellWidth.toInt()
+                                    minFolderCellWidth.toInt()
                                 } catch (_: NumberFormatException) {
-                                    minCellWidthIsError = true
+                                    minFolderCellWidthIsError = true
                                     0
                                 }
 
                                 val minCellHeight = try {
-                                    minCellHeight.toInt()
+                                    minFolderCellHeight.toInt()
                                 } catch (_: NumberFormatException) {
-                                    minCellHeightIsError = true
+                                    minFolderCellHeightIsError = true
                                     0
                                 }
 
                                 val maxCellWidth = try {
-                                    maxCellWidth.toInt()
+                                    maxFolderCellWidth.toInt()
                                 } catch (_: NumberFormatException) {
-                                    maxCellWidthIsError = true
+                                    maxFolderCellWidthIsError = true
                                     0
                                 }
 
                                 val maxCellHeight = try {
-                                    maxCellHeight.toInt()
+                                    maxFolderCellHeight.toInt()
                                 } catch (_: NumberFormatException) {
-                                    maxCellHeightIsError = true
+                                    maxFolderCellHeightIsError = true
                                     0
                                 }
 
@@ -212,10 +212,10 @@ internal fun FolderCellDimensionDialog(
                                 ) {
                                     onUpdateHomeSettings(
                                         homeSettings.copy(
-                                            minCellWidth = minCellWidth,
-                                            minCellHeight = minCellHeight,
-                                            maxCellWidth = maxCellWidth,
-                                            maxCellHeight = maxCellHeight,
+                                            minFolderCellWidth = minCellWidth,
+                                            minFolderCellHeight = minCellHeight,
+                                            maxFolderCellWidth = maxCellWidth,
+                                            maxFolderCellHeight = maxCellHeight,
                                         ),
                                     )
 


### PR DESCRIPTION
Closes #787 

- Added `minCellWidth`, `minCellHeight`, `maxCellWidth`, and `maxCellHeight` fields to the `HomeSettings` protocol buffer definition and domain model.
- Updated `DataStoreMapper` to handle the transformation of these new dimension properties between the data and domain layers.
- Integrated a new "Folder" settings section in `HomeSettingsScreen`, featuring an "Folder Cell Dimension" option.
- Created `FolderCellDimensionDialog` to allow users to customize minimum and maximum folder cell sizes, including input validation for numeric values.
- Updated the UI state management in `HomeSettingsScreen` to handle the visibility and persistence logic for the new dimension settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable folder cell dimensions in home settings. Users can now adjust the width and height of folder items through the settings interface to personalize their layout preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JackEblan/YagniLauncher/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->